### PR TITLE
Remove rotation and erosion.

### DIFF
--- a/DotNet/CesiumLanguageWriter/CesiumWritingHelper.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumWritingHelper.cs
@@ -374,10 +374,10 @@ namespace CesiumLanguageWriter
             {
                 output.WriteValue(epoch.SecondsDifference(dates[i]));
                 UnitQuaternion quaternion = values[i];
-                output.WriteValue(quaternion.W);
                 output.WriteValue(quaternion.X);
                 output.WriteValue(quaternion.Y);
                 output.WriteValue(quaternion.Z);
+                output.WriteValue(quaternion.W);
                 output.WriteLineBreak();
             }
 

--- a/DotNet/CesiumLanguageWriter/Generated/BillboardCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/BillboardCesiumWriter.cs
@@ -39,11 +39,6 @@ namespace CesiumLanguageWriter
         public const string PixelOffsetPropertyName = "pixelOffset";
 
         /// <summary>
-        /// The name of the <code>rotation</code> property.
-        /// </summary>
-        public const string RotationPropertyName = "rotation";
-
-        /// <summary>
         /// The name of the <code>scale</code> property.
         /// </summary>
         public const string ScalePropertyName = "scale";
@@ -63,7 +58,6 @@ namespace CesiumLanguageWriter
         private readonly Lazy<HorizontalOriginCesiumWriter> m_horizontalOrigin = new Lazy<HorizontalOriginCesiumWriter>(() => new HorizontalOriginCesiumWriter(HorizontalOriginPropertyName), false);
         private readonly Lazy<ImageCesiumWriter> m_image = new Lazy<ImageCesiumWriter>(() => new ImageCesiumWriter(ImagePropertyName), false);
         private readonly Lazy<PixelOffsetCesiumWriter> m_pixelOffset = new Lazy<PixelOffsetCesiumWriter>(() => new PixelOffsetCesiumWriter(PixelOffsetPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_rotation = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RotationPropertyName), false);
         private readonly Lazy<DoubleCesiumWriter> m_scale = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ScalePropertyName), false);
         private readonly Lazy<BooleanCesiumWriter> m_show = new Lazy<BooleanCesiumWriter>(() => new BooleanCesiumWriter(ShowPropertyName), false);
         private readonly Lazy<VerticalOriginCesiumWriter> m_verticalOrigin = new Lazy<VerticalOriginCesiumWriter>(() => new VerticalOriginCesiumWriter(VerticalOriginPropertyName), false);
@@ -359,50 +353,6 @@ namespace CesiumLanguageWriter
             using (var writer = OpenPixelOffsetProperty())
             {
                 writer.WriteCartesian2(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>rotation</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>rotation</code> property defines the rotation of the billboard expressed as a clockwise rotation in radians.
-        /// </summary>
-        public DoubleCesiumWriter RotationWriter
-        {
-            get { return m_rotation.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>rotation</code> property.  The <code>rotation</code> property defines the rotation of the billboard expressed as a clockwise rotation in radians.
-        /// </summary>
-        public DoubleCesiumWriter OpenRotationProperty()
-        {
-            OpenIntervalIfNecessary();
-            return OpenAndReturn(RotationWriter);
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the rotation of the billboard expressed as a clockwise rotation in radians.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteRotationProperty(double value)
-        {
-            using (var writer = OpenRotationProperty())
-            {
-                writer.WriteNumber(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the rotation of the billboard expressed as a clockwise rotation in radians.
-        /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteRotationProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
-        {
-            using (var writer = OpenRotationProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
             }
         }
 

--- a/DotNet/CesiumLanguageWriter/Generated/ConeCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ConeCesiumWriter.cs
@@ -54,11 +54,6 @@ namespace CesiumLanguageWriter
         public const string IntersectionColorPropertyName = "intersectionColor";
 
         /// <summary>
-        /// The name of the <code>erosion</code> property.
-        /// </summary>
-        public const string ErosionPropertyName = "erosion";
-
-        /// <summary>
         /// The name of the <code>capMaterial</code> property.
         /// </summary>
         public const string CapMaterialPropertyName = "capMaterial";
@@ -86,7 +81,6 @@ namespace CesiumLanguageWriter
         private readonly Lazy<DoubleCesiumWriter> m_maximumClockAngle = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(MaximumClockAnglePropertyName), false);
         private readonly Lazy<BooleanCesiumWriter> m_showIntersection = new Lazy<BooleanCesiumWriter>(() => new BooleanCesiumWriter(ShowIntersectionPropertyName), false);
         private readonly Lazy<ColorCesiumWriter> m_intersectionColor = new Lazy<ColorCesiumWriter>(() => new ColorCesiumWriter(IntersectionColorPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_erosion = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ErosionPropertyName), false);
         private readonly Lazy<MaterialCesiumWriter> m_capMaterial = new Lazy<MaterialCesiumWriter>(() => new MaterialCesiumWriter(CapMaterialPropertyName), false);
         private readonly Lazy<MaterialCesiumWriter> m_innerMaterial = new Lazy<MaterialCesiumWriter>(() => new MaterialCesiumWriter(InnerMaterialPropertyName), false);
         private readonly Lazy<MaterialCesiumWriter> m_outerMaterial = new Lazy<MaterialCesiumWriter>(() => new MaterialCesiumWriter(OuterMaterialPropertyName), false);
@@ -464,50 +458,6 @@ namespace CesiumLanguageWriter
             using (var writer = OpenIntersectionColorProperty())
             {
                 writer.WriteRgbaf(red, green, blue, alpha);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>erosion</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>erosion</code> property defines the erosion of the cone.
-        /// </summary>
-        public DoubleCesiumWriter ErosionWriter
-        {
-            get { return m_erosion.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>erosion</code> property.  The <code>erosion</code> property defines the erosion of the cone.
-        /// </summary>
-        public DoubleCesiumWriter OpenErosionProperty()
-        {
-            OpenIntervalIfNecessary();
-            return OpenAndReturn(ErosionWriter);
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the cone.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteErosionProperty(double value)
-        {
-            using (var writer = OpenErosionProperty())
-            {
-                writer.WriteNumber(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the cone.
-        /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteErosionProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
-        {
-            using (var writer = OpenErosionProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
             }
         }
 

--- a/DotNet/CesiumLanguageWriter/Generated/PyramidCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PyramidCesiumWriter.cs
@@ -39,11 +39,6 @@ namespace CesiumLanguageWriter
         public const string IntersectionColorPropertyName = "intersectionColor";
 
         /// <summary>
-        /// The name of the <code>erosion</code> property.
-        /// </summary>
-        public const string ErosionPropertyName = "erosion";
-
-        /// <summary>
         /// The name of the <code>material</code> property.
         /// </summary>
         public const string MaterialPropertyName = "material";
@@ -53,7 +48,6 @@ namespace CesiumLanguageWriter
         private readonly Lazy<DoubleCesiumWriter> m_radius = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RadiusPropertyName), false);
         private readonly Lazy<BooleanCesiumWriter> m_showIntersection = new Lazy<BooleanCesiumWriter>(() => new BooleanCesiumWriter(ShowIntersectionPropertyName), false);
         private readonly Lazy<ColorCesiumWriter> m_intersectionColor = new Lazy<ColorCesiumWriter>(() => new ColorCesiumWriter(IntersectionColorPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_erosion = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ErosionPropertyName), false);
         private readonly Lazy<MaterialCesiumWriter> m_material = new Lazy<MaterialCesiumWriter>(() => new MaterialCesiumWriter(MaterialPropertyName), false);
 
         /// <summary>
@@ -293,50 +287,6 @@ namespace CesiumLanguageWriter
             using (var writer = OpenIntersectionColorProperty())
             {
                 writer.WriteRgbaf(red, green, blue, alpha);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>erosion</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>erosion</code> property defines the erosion of the pyramid.
-        /// </summary>
-        public DoubleCesiumWriter ErosionWriter
-        {
-            get { return m_erosion.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>erosion</code> property.  The <code>erosion</code> property defines the erosion of the pyramid.
-        /// </summary>
-        public DoubleCesiumWriter OpenErosionProperty()
-        {
-            OpenIntervalIfNecessary();
-            return OpenAndReturn(ErosionWriter);
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the pyramid.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteErosionProperty(double value)
-        {
-            using (var writer = OpenErosionProperty())
-            {
-                writer.WriteNumber(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the pyramid.
-        /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteErosionProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
-        {
-            using (var writer = OpenErosionProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
             }
         }
 

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/BillboardCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/BillboardCesiumWriter.java
@@ -54,13 +54,6 @@ public class BillboardCesiumWriter extends CesiumPropertyWriter<BillboardCesiumW
 	public static final String PixelOffsetPropertyName = "pixelOffset";
 	/**
 	 *  
-	The name of the <code>rotation</code> property.
-	
-
-	 */
-	public static final String RotationPropertyName = "rotation";
-	/**
-	 *  
 	The name of the <code>scale</code> property.
 	
 
@@ -103,11 +96,6 @@ public class BillboardCesiumWriter extends CesiumPropertyWriter<BillboardCesiumW
 	private Lazy<PixelOffsetCesiumWriter> m_pixelOffset = new Lazy<PixelOffsetCesiumWriter>(new Func1<PixelOffsetCesiumWriter>() {
 		public PixelOffsetCesiumWriter invoke() {
 			return new PixelOffsetCesiumWriter(PixelOffsetPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_rotation = new Lazy<DoubleCesiumWriter>(new Func1<DoubleCesiumWriter>() {
-		public DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(RotationPropertyName);
 		}
 	}, false);
 	private Lazy<DoubleCesiumWriter> m_scale = new Lazy<DoubleCesiumWriter>(new Func1<DoubleCesiumWriter>() {
@@ -549,70 +537,6 @@ public class BillboardCesiumWriter extends CesiumPropertyWriter<BillboardCesiumW
 			cesiumlanguagewriter.PixelOffsetCesiumWriter writer = openPixelOffsetProperty();
 			try {
 				writer.writeCartesian2(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>rotation</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>rotation</code> property defines the rotation of the billboard expressed as a clockwise rotation in radians.
-	
-
-	 */
-	public final DoubleCesiumWriter getRotationWriter() {
-		return m_rotation.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>rotation</code> property.  The <code>rotation</code> property defines the rotation of the billboard expressed as a clockwise rotation in radians.
-	
-
-	 */
-	public final DoubleCesiumWriter openRotationProperty() {
-		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getRotationWriter());
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the rotation of the billboard expressed as a clockwise rotation in radians.
-	
-	
-
-	 * @param value The value.
-	 */
-	public final void writeRotationProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRotationProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the rotation of the billboard expressed as a clockwise rotation in radians.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeRotationProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRotationProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/CesiumWritingHelper.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/CesiumWritingHelper.java
@@ -457,10 +457,10 @@ public final class CesiumWritingHelper {
 		for (int i = startIndex; i < last; ++i) {
 			output.writeValue(epoch.secondsDifference(dates.get(i)));
 			UnitQuaternion quaternion = values.get(i);
-			output.writeValue(quaternion.getW());
 			output.writeValue(quaternion.getX());
 			output.writeValue(quaternion.getY());
 			output.writeValue(quaternion.getZ());
+			output.writeValue(quaternion.getW());
 			output.writeLineBreak();
 		}
 		output.writeEndSequence();

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ConeCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ConeCesiumWriter.java
@@ -74,13 +74,6 @@ public class ConeCesiumWriter extends CesiumPropertyWriter<ConeCesiumWriter> {
 	public static final String IntersectionColorPropertyName = "intersectionColor";
 	/**
 	 *  
-	The name of the <code>erosion</code> property.
-	
-
-	 */
-	public static final String ErosionPropertyName = "erosion";
-	/**
-	 *  
 	The name of the <code>capMaterial</code> property.
 	
 
@@ -145,11 +138,6 @@ public class ConeCesiumWriter extends CesiumPropertyWriter<ConeCesiumWriter> {
 	private Lazy<ColorCesiumWriter> m_intersectionColor = new Lazy<ColorCesiumWriter>(new Func1<ColorCesiumWriter>() {
 		public ColorCesiumWriter invoke() {
 			return new ColorCesiumWriter(IntersectionColorPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_erosion = new Lazy<DoubleCesiumWriter>(new Func1<DoubleCesiumWriter>() {
-		public DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(ErosionPropertyName);
 		}
 	}, false);
 	private Lazy<MaterialCesiumWriter> m_capMaterial = new Lazy<MaterialCesiumWriter>(new Func1<MaterialCesiumWriter>() {
@@ -706,70 +694,6 @@ public class ConeCesiumWriter extends CesiumPropertyWriter<ConeCesiumWriter> {
 			cesiumlanguagewriter.ColorCesiumWriter writer = openIntersectionColorProperty();
 			try {
 				writer.writeRgbaf(red, green, blue, alpha);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>erosion</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>erosion</code> property defines the erosion of the cone.
-	
-
-	 */
-	public final DoubleCesiumWriter getErosionWriter() {
-		return m_erosion.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>erosion</code> property.  The <code>erosion</code> property defines the erosion of the cone.
-	
-
-	 */
-	public final DoubleCesiumWriter openErosionProperty() {
-		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getErosionWriter());
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the cone.
-	
-	
-
-	 * @param value The value.
-	 */
-	public final void writeErosionProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openErosionProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the cone.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeErosionProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openErosionProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PyramidCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PyramidCesiumWriter.java
@@ -53,13 +53,6 @@ public class PyramidCesiumWriter extends CesiumPropertyWriter<PyramidCesiumWrite
 	public static final String IntersectionColorPropertyName = "intersectionColor";
 	/**
 	 *  
-	The name of the <code>erosion</code> property.
-	
-
-	 */
-	public static final String ErosionPropertyName = "erosion";
-	/**
-	 *  
 	The name of the <code>material</code> property.
 	
 
@@ -88,11 +81,6 @@ public class PyramidCesiumWriter extends CesiumPropertyWriter<PyramidCesiumWrite
 	private Lazy<ColorCesiumWriter> m_intersectionColor = new Lazy<ColorCesiumWriter>(new Func1<ColorCesiumWriter>() {
 		public ColorCesiumWriter invoke() {
 			return new ColorCesiumWriter(IntersectionColorPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_erosion = new Lazy<DoubleCesiumWriter>(new Func1<DoubleCesiumWriter>() {
-		public DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(ErosionPropertyName);
 		}
 	}, false);
 	private Lazy<MaterialCesiumWriter> m_material = new Lazy<MaterialCesiumWriter>(new Func1<MaterialCesiumWriter>() {
@@ -436,70 +424,6 @@ public class PyramidCesiumWriter extends CesiumPropertyWriter<PyramidCesiumWrite
 			cesiumlanguagewriter.ColorCesiumWriter writer = openIntersectionColorProperty();
 			try {
 				writer.writeRgbaf(red, green, blue, alpha);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>erosion</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>erosion</code> property defines the erosion of the pyramid.
-	
-
-	 */
-	public final DoubleCesiumWriter getErosionWriter() {
-		return m_erosion.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>erosion</code> property.  The <code>erosion</code> property defines the erosion of the pyramid.
-	
-
-	 */
-	public final DoubleCesiumWriter openErosionProperty() {
-		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getErosionWriter());
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the pyramid.
-	
-	
-
-	 * @param value The value.
-	 */
-	public final void writeErosionProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openErosionProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>erosion</code> property as a <code>number</code> value.  The <code>erosion</code> property specifies the erosion of the pyramid.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeErosionProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openErosionProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}

--- a/Schema/Billboard.jsonschema
+++ b/Schema/Billboard.jsonschema
@@ -24,10 +24,6 @@
             "$ref": "PixelOffset.jsonschema",
             "description": "The offset, in viewport pixels, of the billboard origin from the `position`.  A pixel offset is the number of pixels up and to the right to place the billboard, relative to the `position`."
         },
-        "rotation": {
-            "$ref": "Double.jsonschema",
-            "description": "The rotation of the billboard expressed as a clockwise rotation in radians."
-        },
         "scale": {
             "$ref": "Double.jsonschema",
             "description": "The scale of the billboard.  The scale is multiplied with the pixel size of the billboard's `image`.  For example, if the scale is 2.0, the billboard will be rendered with twice the number of pixels, in each direction, of the `image`."

--- a/Schema/Cone.jsonschema
+++ b/Schema/Cone.jsonschema
@@ -36,10 +36,6 @@
             "$ref": "Color.jsonschema",
             "description": "The color of the intersection of the cone with the Earth."
         },
-        "erosion": {
-            "$ref": "Double.jsonschema",
-            "description": "The erosion of the cone."
-        },
         "capMaterial": {
             "$ref": "Material.jsonschema",
             "description": "The material to use to cap the cone at its radial limit."

--- a/Schema/Pyramid.jsonschema
+++ b/Schema/Pyramid.jsonschema
@@ -24,10 +24,6 @@
             "$ref": "Color.jsonschema",
             "description": "The color of the intersection of the pyramid with the Earth."
         },
-        "erosion": {
-            "$ref": "Double.jsonschema",
-            "description": "The erosion of the pyramid."
-        },
         "material": {
             "$ref": "Material.jsonschema",
             "description": "The material to display on the surface of the pyramid."


### PR DESCRIPTION
1. Erosion doesn't really make sense in the context of CZML, it's just a demo feature in Cesium right now.
2. Billboard rotation can't really be expressed in 3D with a single double, we'll revisit it in the future.
