### PR TITLE
WebGL Globe JSON Converter Tweaks

### DIFF
--- a/DotNet/WebGlGlobeJsonToCesiumLanguage/Series.cs
+++ b/DotNet/WebGlGlobeJsonToCesiumLanguage/Series.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using CesiumLanguageWriter;
 
 namespace WebGLGlobeJsonToCesiumLanguage
@@ -11,18 +12,18 @@ namespace WebGLGlobeJsonToCesiumLanguage
         /// <param name="id">The ID of the <see cref="Series"/></param>
         /// <param name="coordinatesDegrees">An array of <see cref="Cartographic"/> positions 
         /// where the latitude and longitude are given in degrees.</param>
-        /// <param name="color">The color used to visually represent the series.</param>
+        /// <param name="heightScalar">A value used to scale the height of each coordinate.</param>
         /// <example>
         /// CzmlDocument document = new CzmlDocument();
         /// Cartographic[] positions = new Cartographic[] { new Cartographic(45.0, -90.0, 300), new Cartographic(50.0, -100.0, 400) };
         /// Series series = new Series("test", positions, document);
         /// </example>
-        public Series(string id, Cartographic[] coordinatesDegrees, CzmlDocument document, Color color)
+        public Series(string id, Cartographic[] coordinatesDegrees, CzmlDocument document, double heightScalar = 1.0)
         {        
             m_id = id;
             m_document = document;
             m_coordinates = (Cartographic[])coordinatesDegrees.Clone();
-            m_color = color;
+            m_scalar = heightScalar;
         }
 
         /// <summary>
@@ -42,11 +43,11 @@ namespace WebGLGlobeJsonToCesiumLanguage
         }
 
         /// <summary>
-        /// Gets the array of rgba color values.
+        /// Gets the height scalar.
         /// </summary>
-        public Color Color
+        public double Scalar
         {
-            get { return m_color; }
+            get { return m_scalar; }
         }
 
         /// <summary>
@@ -74,22 +75,46 @@ namespace WebGLGlobeJsonToCesiumLanguage
                     packetWriter.WriteId(m_id + index);
                     using (PolylineCesiumWriter polyline = packetWriter.OpenPolylineProperty())
                     {
-                        polyline.WriteColorProperty(m_color);
+                        polyline.WriteColorProperty(ColorFromHSV(0.6 - (m_coordinates[index].Height * 0.5), 1.0, 1.0));
                     }
                     using (PositionListCesiumWriter vertexPositions = packetWriter.OpenVertexPositionsProperty())
                     {
                         Cartographic[] positions = new Cartographic[] {
                             new Cartographic(m_coordinates[index].Longitude, m_coordinates[index].Latitude, 0.0),
-                            m_coordinates[index] };
+                            new Cartographic(m_coordinates[index].Longitude, m_coordinates[index].Latitude, m_coordinates[index].Height * m_scalar)};
                         vertexPositions.WriteCartographicDegrees(positions);
                     }
                 }
             }
         }
 
+        private Color ColorFromHSV(double hue, double saturation, double value)
+        {
+            int i = Convert.ToInt32(Math.Floor(hue * 6));
+            double f = hue * 6 - i;
+
+            value = value * 255;
+            int v = Convert.ToInt32(value);
+            int p = Convert.ToInt32(value * (1 - saturation));
+            int q = Convert.ToInt32(value * (1 - f * saturation));
+            int t = Convert.ToInt32(value * (1 - (1 - f) * saturation));
+
+            Color color = Color.Red;
+            switch (i % 6)
+            {
+                case 0: color = Color.FromArgb(255, v, t, p); break;
+                case 1: color = Color.FromArgb(255, q, v, p); break;
+                case 2: color = Color.FromArgb(255, p, v, t); break;
+                case 3: color = Color.FromArgb(255, p, q, v); break;
+                case 4: color = Color.FromArgb(255, t, p, v); break;
+                case 5: color = Color.FromArgb(255, v, p, q); break;
+            }
+            return color;
+        }
+
         private readonly string m_id;
         private readonly Cartographic[] m_coordinates;
         private readonly CzmlDocument m_document;
-        private readonly Color m_color;
+        private readonly double m_scalar;
     }
 }

--- a/DotNet/WebGlGlobeJsonToCesiumLanguage/WebGlGlobeJsonConverter.cs
+++ b/DotNet/WebGlGlobeJsonToCesiumLanguage/WebGlGlobeJsonConverter.cs
@@ -17,7 +17,6 @@ namespace WebGLGlobeJsonToCesiumLanguage
         /// <param name="heightScalar">An optional value used to scale the height component of each coordinate.</param>
         public static void WebGLGlobeJsonToCesiumLanguage(TextReader jsonContents,
                                                           CzmlDocument document,
-                                                          Color? color = null,
                                                           double heightScalar = 1.0)
         {
             JsonTextReader jsReader = new JsonTextReader(jsonContents);
@@ -36,11 +35,10 @@ namespace WebGLGlobeJsonToCesiumLanguage
                 Cartographic[] coords = new Cartographic[numCoordinateComponents / 3];
                 for (int i = 0, j = 0; i < numCoordinateComponents; i += 3, j++)
                 {
-                    coords[j] = new Cartographic((double)item[1][i], (double)item[1][i + 1], heightScalar * (double)item[1][i + 2]);
+                    coords[j] = new Cartographic((double)item[1][i + 1], (double)item[1][i], (double)item[1][i + 2]);
                 }
 
-                Color c = color.HasValue ? color.Value : Color.Blue;
-                Series series = new Series((string)item[0], coords, document, c);
+                Series series = new Series((string)item[0], coords, document, heightScalar);
                 series.Write();
             }
 

--- a/DotNet/WebGlGlobeJsonToCesiumLanguageTests/TestSeries.cs
+++ b/DotNet/WebGlGlobeJsonToCesiumLanguageTests/TestSeries.cs
@@ -14,11 +14,11 @@ namespace WebGLGlobeJsonToCesiumLanguageTests
         {
             m_document = new CzmlDocument();
         }
-        
+
         [Test]
         public void UsesCartographicDegrees()
         {
-            Series series = new Series("test", new Cartographic[] {new Cartographic(90.0, 45.0, 3.0)}, m_document, Color.Blue);
+            Series series = new Series("test", new Cartographic[] { new Cartographic(90.0, 45.0, 3.0) }, m_document);
             series.Write();
             string result = m_document.StringWriter.ToString();
             Assert.That(result.Contains("\"cartographicDegrees\":"));
@@ -28,7 +28,7 @@ namespace WebGLGlobeJsonToCesiumLanguageTests
         [Test]
         public void GeneratesIndexedIds()
         {
-            Series series = new Series("test", new Cartographic[] { new Cartographic(1.0, 2.0, 3.0), new Cartographic(4.0, 5.0, 6.0) }, m_document, Color.Blue);
+            Series series = new Series("test", new Cartographic[] { new Cartographic(1.0, 2.0, 3.0), new Cartographic(4.0, 5.0, 6.0) }, m_document);
             series.Write();
             string result = m_document.StringWriter.ToString();
             Assert.That(result.Contains("\"id\":\"test0\""));
@@ -38,7 +38,7 @@ namespace WebGLGlobeJsonToCesiumLanguageTests
         [Test]
         public void ListsVertexPositionsForBothEndPoints()
         {
-            Series series = new Series("test", new Cartographic[] { new Cartographic(1.0, 2.0, 3.0) }, m_document, Color.Blue);
+            Series series = new Series("test", new Cartographic[] { new Cartographic(1.0, 2.0, 3.0) }, m_document);
             series.Write();
             string result = m_document.StringWriter.ToString();
             Assert.That(result.Contains("\"vertexPositions\":{\"cartographicDegrees\":[1.0,2.0,0.0,1.0,2.0,3.0]}"));


### PR DESCRIPTION
This pull request contains a bug fix that swapped longitude/latitude. (Google's JSON format provides (latitude, longitude, height), but the czml-writer Cartographic constructor expects (longitude, latitude, height).)

The colors for polylines are also automatically set based on magnitude, such that the presentation matches that of WebGL Globe.
