### PR TITLE
CZML viewFrom property...

### DIFF
--- a/DotNet/CesiumLanguageWriter/Generated/PacketCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PacketCesiumWriter.cs
@@ -561,7 +561,7 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location.
+        /// Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.
         /// </summary>
         /// <param name="value">The value.</param>
         public void WriteViewFrom(Cartesian value)
@@ -572,7 +572,7 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location.
+        /// Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.
         /// </summary>
         /// <param name="dates">The dates at which the vector is specified.</param>
         /// <param name="values">The values corresponding to each date.</param>
@@ -582,7 +582,7 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location.
+        /// Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.
         /// </summary>
         /// <param name="dates">The dates at which the vector is specified.</param>
         /// <param name="values">The values corresponding to each date.</param>

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PacketCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PacketCesiumWriter.java
@@ -837,7 +837,7 @@ public class PacketCesiumWriter extends CesiumElementWriter {
 
 	/**
 	 *  
-	Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location.
+	Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.
 	
 	
 
@@ -851,7 +851,7 @@ public class PacketCesiumWriter extends CesiumElementWriter {
 
 	/**
 	 *  
-	Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location.
+	Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.
 	
 	
 	
@@ -865,7 +865,7 @@ public class PacketCesiumWriter extends CesiumElementWriter {
 
 	/**
 	 *  
-	Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location.
+	Writes the <code>viewFrom</code> property.  The <code>viewFrom</code> property specifies a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.
 	
 	
 	

--- a/Schema/Packet.jsonschema
+++ b/Schema/Packet.jsonschema
@@ -67,7 +67,7 @@
         },
         "viewFrom": {
             "$ref": "Cartesian3Value.jsonschema",
-            "description": "A suggested Cartesian camera position, when viewing this object in the East (X), North(Y), Up(Z) reference frame relative to the objects location."
+            "description": "A suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property."
         },
     }
 }


### PR DESCRIPTION
This adds a new top-level property `viewFrom`, which is a suggested camera location when viewing an object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property.

Eventually, I could see this property being replaced by the camera system we will eventually have, but this is a simple solution for now that enables us to do a lot more with our demos.
