### PR TITLE
Remove no longer needed #ifdefs

### DIFF
--- a/DotNet/CesiumLanguageWriter/Advanced/CachingCesiumUrlResolver.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CachingCesiumUrlResolver.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// A URL resolver that downloads files and converts them to data URIs.  Downloaded files are cached

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumElementWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumElementWriter.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// The base class for types that write <topic name="Cesium">Cesium</topic> data to a stream.

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumFormattingHelper.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumFormattingHelper.cs
@@ -5,15 +5,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 
-#if StkComponents
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// Contains static methods for formatting data for writing to a <topic name="Cesium">Cesium</topic> stream.
@@ -32,19 +24,6 @@ namespace CesiumLanguageWriter.Advanced
             return ToIso8601(start, format) + "/" + ToIso8601(stop, format);
         }
 
-#if StkComponents
-    /// <summary>
-    /// Converts a <see cref="TimeInterval"/> as an ISO8601 interval string.  The <see cref="TimeInterval.IsStartIncluded"/>
-    /// and <see cref="TimeInterval.IsStopIncluded"/> properties of the interval are ignored.
-    /// </summary>
-    /// <param name="interval">The interval to convert.</param>
-    /// <param name="format">The format to use.</param>
-    /// <returns>The interval represented as an ISO8601 interval string.</returns>
-        public static string ToIso8601Interval(TimeInterval interval, Iso8601Format format)
-        {
-            return ToIso8601Interval(interval.Start, interval.Stop, format);
-        }
-#else
         /// <summary>
         /// Converts a <see cref="TimeInterval"/> as an ISO8601 interval string.
         /// </summary>
@@ -55,7 +34,6 @@ namespace CesiumLanguageWriter.Advanced
         {
             return ToIso8601Interval(interval.Start, interval.Stop, format);
         }
-#endif
 
         /// <summary>
         /// Converts a <see cref="JulianDate"/> to an ISO8601 date string.

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumInterpolatablePropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumInterpolatablePropertyWriter.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// A <topic name="Cesium">Cesium</topic> writer for a property that represents a value that may be sampled

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumInterpolatableWriterAdaptor.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumInterpolatableWriterAdaptor.cs
@@ -1,15 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-#if StkComponents
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// A callback to write a value to a <see cref="CesiumOutputStream"/> using a given

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumPropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumPropertyWriter.cs
@@ -1,14 +1,6 @@
 ﻿using System;
 
-#if StkComponents
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// A <topic name="Cesium">Cesium</topic> writer for a property.  The property may be defined over a

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumWriterAdaptor.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumWriterAdaptor.cs
@@ -1,14 +1,6 @@
 ﻿using System;
 
-#if StkComponents
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// A callback to write a value to a <see cref="CesiumOutputStream"/> using a given

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumWritingHelper.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumWritingHelper.cs
@@ -2,16 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 
-#if StkComponents
-using AGI.Foundation.Coordinates;
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// Contains helper methods for writing CZML values.

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumElementWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumElementWriter.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// An interface to an instance that can write elements of <topic name="Cesium">Cesium</topic>.

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumInterpolatableValuePropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumInterpolatableValuePropertyWriter.cs
@@ -1,14 +1,6 @@
 ﻿using System.Collections.Generic;
 
-#if StkComponents
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
 namespace CesiumLanguageWriter.Advanced
-#endif
 {
     /// <summary>
     /// An interface to a property that writes a sampled, interpolatable value.

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumInterpolationInformationWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumInterpolationInformationWriter.cs
@@ -1,9 +1,4 @@
-﻿
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// An interface to a writer that writes information about how to interpolate sampled values.

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumIntervalListWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumIntervalListWriter.cs
@@ -1,9 +1,4 @@
-﻿
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// An interface to an object that writes a list of intervals for a <topic name="Cesium">Cesium</topic>

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumPropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumPropertyWriter.cs
@@ -1,12 +1,4 @@
-﻿#if StkComponents
-using AGI.Foundation.Time;
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// An interface to an object that writes the values of a <topic name="Cesium">Cesium</topic>

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumUrlResolver.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumUrlResolver.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// A URL resolver transforms URLs into another form for inclusion in a CZML document.

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumValuePropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumValuePropertyWriter.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// An interface to an object that writes the values of a <topic name="Cesium">Cesium</topic>

--- a/DotNet/CesiumLanguageWriter/Advanced/PassThroughCesiumUrlResolver.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/PassThroughCesiumUrlResolver.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium.Advanced
-#else
-namespace CesiumLanguageWriter.Advanced
-#endif
+﻿namespace CesiumLanguageWriter.Advanced
 {
     /// <summary>
     /// A URL resolver that leaves URLs unchanged.

--- a/DotNet/CesiumLanguageWriter/CesiumHorizontalOrigin.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumHorizontalOrigin.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// The horizontal origin of a billboard or label in a <topic name="Cesium">Cesium</topic> stream

--- a/DotNet/CesiumLanguageWriter/CesiumImageFormat.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumImageFormat.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// The format of an image embedded in a <topic name="Cesium">Cesium</topic> stream.

--- a/DotNet/CesiumLanguageWriter/CesiumInterpolationAlgorithm.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumInterpolationAlgorithm.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// The algorithm to use to interpolation sampled data.

--- a/DotNet/CesiumLanguageWriter/CesiumIntervalListWriter.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumIntervalListWriter.cs
@@ -1,15 +1,6 @@
-﻿#if StkComponents
-using AGI.Foundation.Cesium.Advanced;
-using AGI.Foundation.Time;
-#else
-using CesiumLanguageWriter.Advanced;
-#endif
+﻿using CesiumLanguageWriter.Advanced;
 
-#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
 namespace CesiumLanguageWriter
-#endif
 {
     /// <summary>
     /// Writes a list of intervals for which a <topic name="Cesium">Cesium</topic> property is defined.

--- a/DotNet/CesiumLanguageWriter/CesiumLabelStyle.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumLabelStyle.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// Specifies the style of <topic name="Cesium">Cesium</topic> label.

--- a/DotNet/CesiumLanguageWriter/CesiumOutputStream.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumOutputStream.cs
@@ -2,11 +2,7 @@
 using System.Globalization;
 using System.IO;
 
-#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
 namespace CesiumLanguageWriter
-#endif
 {
     /// <summary>
     /// A stream to which raw <topic name="Cesium">Cesium</topic> data can be written.  This is a low-level class that

--- a/DotNet/CesiumLanguageWriter/CesiumResource.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumResource.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// A resource to include in a CZML document, whether embedded or linked to.

--- a/DotNet/CesiumLanguageWriter/CesiumResourceBehavior.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumResourceBehavior.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// Specifies whether to embed resources into a CZML document, or simply link to them.

--- a/DotNet/CesiumLanguageWriter/CesiumStreamWriter.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumStreamWriter.cs
@@ -1,16 +1,7 @@
 ﻿using System;
-
-#if StkComponents
-using AGI.Foundation.Cesium.Advanced;
-#else
 using CesiumLanguageWriter.Advanced;
-#endif
 
-#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
 namespace CesiumLanguageWriter
-#endif
 {
     /// <summary>
     /// Writes <topic name="Cesium">Cesium</topic> data to a <see cref="CesiumOutputStream"/>.

--- a/DotNet/CesiumLanguageWriter/CesiumVerticalOrigin.cs
+++ b/DotNet/CesiumLanguageWriter/CesiumVerticalOrigin.cs
@@ -1,8 +1,4 @@
-﻿#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
-namespace CesiumLanguageWriter
-#endif
+﻿namespace CesiumLanguageWriter
 {
     /// <summary>
     /// The vertical origin of a billboard or label in a <topic name="Cesium">Cesium</topic> stream

--- a/DotNet/CesiumLanguageWriter/CustomCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/CustomCesiumWriter.cs
@@ -1,16 +1,6 @@
-﻿#if StkComponents
-using AGI.Foundation.Cesium.Advanced;
+﻿using CesiumLanguageWriter.Advanced;
 
-#else
-using CesiumLanguageWriter.Advanced;
-
-#endif
-
-#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
 namespace CesiumLanguageWriter
-#endif
 {
     /// <summary>
     /// A <see cref="CesiumPropertyWriter{T}"/> used to write custom properties.  To write custom

--- a/DotNet/CesiumLanguageWriter/TimeConstants.cs
+++ b/DotNet/CesiumLanguageWriter/TimeConstants.cs
@@ -1,10 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-#if StkComponents
-namespace AGI.Foundation.Cesium
-#else
 namespace CesiumLanguageWriter
-#endif
 {
     /// <summary>
     /// Contains time-related constants.

--- a/DotNet/CesiumLanguageWriterTests/TestCesiumInterpolatablePropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriterTests/TestCesiumInterpolatablePropertyWriter.cs
@@ -1,17 +1,8 @@
-﻿#if StkComponents
-using AGI.Foundation.Cesium;
-using AGI.Foundation.Cesium.Advanced;
-#else
-using CesiumLanguageWriter;
+﻿using CesiumLanguageWriter;
 using CesiumLanguageWriter.Advanced;
-#endif
 using NUnit.Framework;
 
-#if StkComponents
-namespace Cesium.Tests.Cesium
-#else
 namespace CesiumLanguageWriterTests
-#endif
 {
     public abstract class TestCesiumInterpolatablePropertyWriter<TDerived> : TestCesiumPropertyWriter<TDerived>
         where TDerived : CesiumInterpolatablePropertyWriter<TDerived>

--- a/DotNet/CesiumLanguageWriterTests/TestCesiumPacketWriter.cs
+++ b/DotNet/CesiumLanguageWriterTests/TestCesiumPacketWriter.cs
@@ -1,28 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-#if StkComponents
-using AGI.Foundation;
-using AGI.Foundation.Cesium;
-using AGI.Foundation.Cesium.Advanced;
-using AGI.Foundation.Coordinates;
-using AGI.Foundation.Time;
-using AGI.Test;
-#else
 using CesiumLanguageWriter;
-#endif
 using NUnit.Framework;
 
-#if StkComponents
-namespace Cesium.Tests.Cesium
-#else
 namespace CesiumLanguageWriterTests
-#endif
 {
     [TestFixture]
     public class TestCesiumPacketWriter
-#if StkComponents
-        : ComponentsTestBase
-#endif
     {
         private StringWriter m_sw;
         private CesiumOutputStream m_output;

--- a/DotNet/CesiumLanguageWriterTests/TestCesiumStreamWriter.cs
+++ b/DotNet/CesiumLanguageWriterTests/TestCesiumStreamWriter.cs
@@ -1,25 +1,12 @@
 ﻿using System;
 using System.IO;
-#if StkComponents
-using AGI.Foundation.Cesium;
-using AGI.Foundation.Cesium.Advanced;
-using AGI.Test;
-#else
 using CesiumLanguageWriter;
-#endif
 using NUnit.Framework;
 
-#if StkComponents
-namespace Cesium.Tests.Cesium
-#else
 namespace CesiumLanguageWriterTests
-#endif
 {
     [TestFixture]
     public class TestCesiumStreamWriter
-#if StkComponents
-        : ComponentsTestBase
-#endif
     {
         private StringWriter m_sw;
         private CesiumOutputStream m_output;
@@ -55,7 +42,7 @@ namespace CesiumLanguageWriterTests
         }
 
         [Test]
-        [ExpectedException(typeof(InvalidOperationException), ExpectedMessage="already opened", MatchType=MessageMatch.Contains)]
+        [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "already opened", MatchType = MessageMatch.Contains)]
         public void MultipleCallsToNewPacketWithoutCloseThrowInvalidOperationException()
         {
             PacketCesiumWriter packet = m_writer.OpenPacket(m_output);

--- a/DotNet/CesiumLanguageWriterTests/TestOrientationCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriterTests/TestOrientationCesiumWriter.cs
@@ -1,23 +1,11 @@
 ﻿using System;
-#if StkComponents
-using AGI.Foundation.Coordinates;
-using AGI.Foundation.Cesium;
-using AGI.Foundation.Cesium.Advanced;
-using AGI.Foundation.Time;
-using AGI.Foundation;
-#else
+using System.Collections.Generic;
+using System.IO;
 using CesiumLanguageWriter;
 using CesiumLanguageWriter.Advanced;
-#endif
 using NUnit.Framework;
-using System.IO;
-using System.Collections.Generic;
 
-#if StkComponents
-namespace Cesium.Tests.Cesium
-#else
 namespace CesiumLanguageWriterTests
-#endif
 {
     [TestFixture]
     class TestOrientationCesiumWriter : TestCesiumInterpolatablePropertyWriter<OrientationCesiumWriter>
@@ -100,13 +88,13 @@ namespace CesiumLanguageWriterTests
                         }
                     }
 
-                    
-                    
+
+
                 }
 
                 Console.WriteLine(sw.ToString());
             }
-            
+
         }
 
     }

--- a/DotNet/CesiumLanguageWriterTests/TestPositionCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriterTests/TestPositionCesiumWriter.cs
@@ -1,22 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-#if StkComponents
-using AGI.Foundation;
-using AGI.Foundation.Cesium;
-using AGI.Foundation.Cesium.Advanced;
-using AGI.Foundation.Coordinates;
-using AGI.Foundation.Time;
-#else
 using CesiumLanguageWriter;
 using CesiumLanguageWriter.Advanced;
-#endif
 using NUnit.Framework;
 
-#if StkComponents
-namespace Cesium.Tests.Cesium
-#else
 namespace CesiumLanguageWriterTests
-#endif
 {
     [TestFixture]
     public class TestPositionCesiumWriter : TestCesiumInterpolatablePropertyWriter<PositionCesiumWriter>


### PR DESCRIPTION
Since we're going to try an alternative method for keeping czml-writer and STK Components up to date, we can remove all of these ugly #ifdefs.
