### PR TITLE
CZML Model support.

### DIFF
--- a/DotNet/CesiumLanguageWriter.sln
+++ b/DotNet/CesiumLanguageWriter.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CesiumLanguageWriter", "CesiumLanguageWriter\CesiumLanguageWriter.csproj", "{085359F8-CC1D-4561-94C7-0BF067B8E370}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CesiumLanguageWriterTests", "CesiumLanguageWriterTests\CesiumLanguageWriterTests.csproj", "{1D5CE515-81E3-47AE-8D02-3767DD8CB07E}"
@@ -40,6 +40,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Schema", "Schema", "{04E49F
 		..\Schema\LabelStyle.jsonschema = ..\Schema\LabelStyle.jsonschema
 		..\Schema\LabelStyleValue.jsonschema = ..\Schema\LabelStyleValue.jsonschema
 		..\Schema\Material.jsonschema = ..\Schema\Material.jsonschema
+		..\Schema\Model.jsonschema = ..\Schema\Model.jsonschema
+		..\Schema\ModelUri.jsonschema = ..\Schema\ModelUri.jsonschema
+		..\Schema\ModelUriValue.jsonschema = ..\Schema\ModelUriValue.jsonschema
 		..\Schema\Orientation.jsonschema = ..\Schema\Orientation.jsonschema
 		..\Schema\Packet.jsonschema = ..\Schema\Packet.jsonschema
 		..\Schema\Path.jsonschema = ..\Schema\Path.jsonschema

--- a/DotNet/CesiumLanguageWriter/CesiumLanguageWriter.csproj
+++ b/DotNet/CesiumLanguageWriter/CesiumLanguageWriter.csproj
@@ -93,6 +93,8 @@
     <Compile Include="Generated\LabelCesiumWriter.cs" />
     <Compile Include="Generated\LabelStyleCesiumWriter.cs" />
     <Compile Include="Generated\MaterialCesiumWriter.cs" />
+    <Compile Include="Generated\ModelCesiumWriter.cs" />
+    <Compile Include="Generated\ModelUriCesiumWriter.cs" />
     <Compile Include="Generated\OrientationCesiumWriter.cs" />
     <Compile Include="Generated\PacketCesiumWriter.cs" />
     <Compile Include="Generated\PathCesiumWriter.cs" />

--- a/DotNet/CesiumLanguageWriter/Generated/ModelCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ModelCesiumWriter.cs
@@ -1,0 +1,224 @@
+// This file was generated automatically by GenerateFromSchema.  Do NOT edit it.
+// https://github.com/AnalyticalGraphicsInc/czml-writer
+
+using CesiumLanguageWriter.Advanced;
+using System;
+using System.Collections.Generic;
+
+namespace CesiumLanguageWriter
+{
+    /// <summary>
+    /// Writes a <code>Model</code> to a <see cref="CesiumOutputStream" />.  A <code>Model</code> defines a 3D model.
+    /// </summary>
+    public class ModelCesiumWriter : CesiumPropertyWriter<ModelCesiumWriter>
+    {
+        /// <summary>
+        /// The name of the <code>show</code> property.
+        /// </summary>
+        public const string ShowPropertyName = "show";
+
+        /// <summary>
+        /// The name of the <code>scale</code> property.
+        /// </summary>
+        public const string ScalePropertyName = "scale";
+
+        /// <summary>
+        /// The name of the <code>uri</code> property.
+        /// </summary>
+        public const string UriPropertyName = "uri";
+
+        private readonly Lazy<BooleanCesiumWriter> m_show = new Lazy<BooleanCesiumWriter>(() => new BooleanCesiumWriter(ShowPropertyName), false);
+        private readonly Lazy<DoubleCesiumWriter> m_scale = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ScalePropertyName), false);
+        private readonly Lazy<ModelUriCesiumWriter> m_uri = new Lazy<ModelUriCesiumWriter>(() => new ModelUriCesiumWriter(UriPropertyName), false);
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public ModelCesiumWriter(string propertyName)
+            : base(propertyName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance as a copy of an existing instance.
+        /// </summary>
+        /// <param name="existingInstance">The existing instance to copy.</param> 
+        protected ModelCesiumWriter(ModelCesiumWriter existingInstance)
+            : base(existingInstance)
+        {
+        }
+
+        /// <inheritdoc />
+        public override ModelCesiumWriter Clone()
+        {
+            return new ModelCesiumWriter(this);
+        }
+
+        /// <summary>
+        /// Gets the writer for the <code>show</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>show</code> property defines whether or not the model is shown.
+        /// </summary>
+        public BooleanCesiumWriter ShowWriter
+        {
+            get { return m_show.Value; }
+        }
+
+        /// <summary>
+        /// Opens and returns the writer for the <code>show</code> property.  The <code>show</code> property defines whether or not the model is shown.
+        /// </summary>
+        public BooleanCesiumWriter OpenShowProperty()
+        {
+            OpenIntervalIfNecessary();
+            return OpenAndReturn(ShowWriter);
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>show</code> property as a <code>boolean</code> value.  The <code>show</code> property specifies whether or not the model is shown.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public void WriteShowProperty(bool value)
+        {
+            using (var writer = OpenShowProperty())
+            {
+                writer.WriteBoolean(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets the writer for the <code>scale</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>scale</code> property defines the scale of the model.
+        /// </summary>
+        public DoubleCesiumWriter ScaleWriter
+        {
+            get { return m_scale.Value; }
+        }
+
+        /// <summary>
+        /// Opens and returns the writer for the <code>scale</code> property.  The <code>scale</code> property defines the scale of the model.
+        /// </summary>
+        public DoubleCesiumWriter OpenScaleProperty()
+        {
+            OpenIntervalIfNecessary();
+            return OpenAndReturn(ScaleWriter);
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>scale</code> property as a <code>number</code> value.  The <code>scale</code> property specifies the scale of the model.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public void WriteScaleProperty(double value)
+        {
+            using (var writer = OpenScaleProperty())
+            {
+                writer.WriteNumber(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>scale</code> property as a <code>number</code> value.  The <code>scale</code> property specifies the scale of the model.
+        /// </summary>
+        /// <param name="dates">The dates at which the value is specified.</param>
+        /// <param name="values">The value corresponding to each date.</param>
+        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
+        /// <param name="length">The number of elements to use from the `values` collection.</param>
+        public void WriteScaleProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
+        {
+            using (var writer = OpenScaleProperty())
+            {
+                writer.WriteNumber(dates, values, startIndex, length);
+            }
+        }
+
+        /// <summary>
+        /// Gets the writer for the <code>uri</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>uri</code> property defines the uri to the model.
+        /// </summary>
+        public ModelUriCesiumWriter UriWriter
+        {
+            get { return m_uri.Value; }
+        }
+
+        /// <summary>
+        /// Opens and returns the writer for the <code>uri</code> property.  The <code>uri</code> property defines the uri to the model.
+        /// </summary>
+        public ModelUriCesiumWriter OpenUriProperty()
+        {
+            OpenIntervalIfNecessary();
+            return OpenAndReturn(UriWriter);
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>uri</code> property as a <code>webgltf</code> value.  The <code>uri</code> property specifies the uri to the model.
+        /// </summary>
+        /// <param name="resource">A resource object describing the model.</param>
+        public void WriteUriProperty(CesiumResource resource)
+        {
+            using (var writer = OpenUriProperty())
+            {
+                writer.WriteWebgltf(resource);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>uri</code> property as a <code>webgltf</code> value.  The <code>uri</code> property specifies the uri to the model.
+        /// </summary>
+        /// <param name="url">The URL of the model.</param>
+        /// <param name="resourceBehavior">An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.</param>
+        public void WriteUriProperty(string url, CesiumResourceBehavior resourceBehavior)
+        {
+            using (var writer = OpenUriProperty())
+            {
+                writer.WriteWebgltf(url, resourceBehavior);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>uri</code> property as a <code>webgltf</code> value.  The <code>uri</code> property specifies the uri to the model.
+        /// </summary>
+        /// <param name="url">The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.</param>
+        /// <param name="resolver">An ICesiumUrlResolver used to build the final URL that will be embedded in the document.</param>
+        public void WriteUriProperty(string url, ICesiumUrlResolver resolver)
+        {
+            using (var writer = OpenUriProperty())
+            {
+                writer.WriteWebgltf(url, resolver);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>uri</code> property as a <code>dae</code> value.  The <code>uri</code> property specifies the uri to the model.
+        /// </summary>
+        /// <param name="resource">A resource object describing the model.</param>
+        public void WriteUriPropertyDae(CesiumResource resource)
+        {
+            using (var writer = OpenUriProperty())
+            {
+                writer.WriteDae(resource);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>uri</code> property as a <code>dae</code> value.  The <code>uri</code> property specifies the uri to the model.
+        /// </summary>
+        /// <param name="url">The URL of the model.</param>
+        /// <param name="resourceBehavior">An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.</param>
+        public void WriteUriPropertyDae(string url, CesiumResourceBehavior resourceBehavior)
+        {
+            using (var writer = OpenUriProperty())
+            {
+                writer.WriteDae(url, resourceBehavior);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>uri</code> property as a <code>dae</code> value.  The <code>uri</code> property specifies the uri to the model.
+        /// </summary>
+        /// <param name="url">The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.</param>
+        /// <param name="resolver">An ICesiumUrlResolver used to build the final URL that will be embedded in the document.</param>
+        public void WriteUriPropertyDae(string url, ICesiumUrlResolver resolver)
+        {
+            using (var writer = OpenUriProperty())
+            {
+                writer.WriteDae(url, resolver);
+            }
+        }
+
+    }
+}

--- a/DotNet/CesiumLanguageWriter/Generated/ModelUriCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ModelUriCesiumWriter.cs
@@ -1,0 +1,155 @@
+// This file was generated automatically by GenerateFromSchema.  Do NOT edit it.
+// https://github.com/AnalyticalGraphicsInc/czml-writer
+
+using CesiumLanguageWriter.Advanced;
+using System;
+
+namespace CesiumLanguageWriter
+{
+    /// <summary>
+    /// Writes a <code>ModelUri</code> to a <see cref="CesiumOutputStream" />.  A <code>ModelUri</code> defines a model associated with an element, which can optionally vary over time.  The model is specified as multiple URLs where each property maps to a different format.  The client can choose its best supported format from those provided.
+    /// </summary>
+    public class ModelUriCesiumWriter : CesiumPropertyWriter<ModelUriCesiumWriter>
+    {
+        /// <summary>
+        /// The name of the <code>webgltf</code> property.
+        /// </summary>
+        public const string WebgltfPropertyName = "webgltf";
+
+        /// <summary>
+        /// The name of the <code>dae</code> property.
+        /// </summary>
+        public const string DaePropertyName = "dae";
+
+        private readonly Lazy<ICesiumValuePropertyWriter<CesiumResource>> m_asWebgltf;
+        private readonly Lazy<ICesiumValuePropertyWriter<CesiumResource>> m_asDae;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        public ModelUriCesiumWriter(string propertyName)
+            : base(propertyName)
+        {
+            m_asWebgltf = new Lazy<ICesiumValuePropertyWriter<CesiumResource>>(CreateWebgltfAdaptor, false);
+            m_asDae = new Lazy<ICesiumValuePropertyWriter<CesiumResource>>(CreateDaeAdaptor, false);
+        }
+
+        /// <summary>
+        /// Initializes a new instance as a copy of an existing instance.
+        /// </summary>
+        /// <param name="existingInstance">The existing instance to copy.</param> 
+        protected ModelUriCesiumWriter(ModelUriCesiumWriter existingInstance)
+            : base(existingInstance)
+        {
+            m_asWebgltf = new Lazy<ICesiumValuePropertyWriter<CesiumResource>>(CreateWebgltfAdaptor, false);
+            m_asDae = new Lazy<ICesiumValuePropertyWriter<CesiumResource>>(CreateDaeAdaptor, false);
+        }
+
+        /// <inheritdoc />
+        public override ModelUriCesiumWriter Clone()
+        {
+            return new ModelUriCesiumWriter(this);
+        }
+
+        /// <summary>
+        /// Writes the <code>webgltf</code> property.  The <code>webgltf</code> property specifies the URL of a WebGLTF model.
+        /// </summary>
+        /// <param name="resource">A resource object describing the model.</param>
+        public void WriteWebgltf(CesiumResource resource)
+        {
+            WriteWebgltf(resource.Url, resource.Behavior);
+        }
+
+        /// <summary>
+        /// Writes the <code>webgltf</code> property.  The <code>webgltf</code> property specifies the URL of a WebGLTF model.
+        /// </summary>
+        /// <param name="url">The URL of the model.</param>
+        /// <param name="resourceBehavior">An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.</param>
+        public void WriteWebgltf(string url, CesiumResourceBehavior resourceBehavior)
+        {
+            const string PropertyName = WebgltfPropertyName;
+            if (IsInterval)
+                Output.WritePropertyName(PropertyName);
+            Output.WriteValue(CesiumFormattingHelper.GetResourceUrl(url, resourceBehavior));
+        }
+
+        /// <summary>
+        /// Writes the <code>webgltf</code> property.  The <code>webgltf</code> property specifies the URL of a WebGLTF model.
+        /// </summary>
+        /// <param name="url">The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.</param>
+        /// <param name="resolver">An ICesiumUrlResolver used to build the final URL that will be embedded in the document.</param>
+        public void WriteWebgltf(string url, ICesiumUrlResolver resolver)
+        {
+            const string PropertyName = WebgltfPropertyName;
+            if (IsInterval)
+                Output.WritePropertyName(PropertyName);
+            Output.WriteValue(resolver.ResolveUrl(url));
+        }
+
+        /// <summary>
+        /// Writes the <code>dae</code> property.  The <code>dae</code> property specifies the URL of a Collada model.
+        /// </summary>
+        /// <param name="resource">A resource object describing the model.</param>
+        public void WriteDae(CesiumResource resource)
+        {
+            WriteDae(resource.Url, resource.Behavior);
+        }
+
+        /// <summary>
+        /// Writes the <code>dae</code> property.  The <code>dae</code> property specifies the URL of a Collada model.
+        /// </summary>
+        /// <param name="url">The URL of the model.</param>
+        /// <param name="resourceBehavior">An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.</param>
+        public void WriteDae(string url, CesiumResourceBehavior resourceBehavior)
+        {
+            const string PropertyName = DaePropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            Output.WriteValue(CesiumFormattingHelper.GetResourceUrl(url, resourceBehavior));
+        }
+
+        /// <summary>
+        /// Writes the <code>dae</code> property.  The <code>dae</code> property specifies the URL of a Collada model.
+        /// </summary>
+        /// <param name="url">The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.</param>
+        /// <param name="resolver">An ICesiumUrlResolver used to build the final URL that will be embedded in the document.</param>
+        public void WriteDae(string url, ICesiumUrlResolver resolver)
+        {
+            const string PropertyName = DaePropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            Output.WriteValue(resolver.ResolveUrl(url));
+        }
+
+        /// <summary>
+        /// Returns a wrapper for this instance that implements <see cref="ICesiumValuePropertyWriter{T}" /> to write a value in <code>Webgltf</code> format.  Because the returned instance is a wrapper for this instance, you may call <see cref="ICesiumElementWriter.Close" /> on either this instance or the wrapper, but you must not call it on both.
+        /// </summary>
+        /// <returns>The wrapper.</returns>
+        public ICesiumValuePropertyWriter<CesiumResource> AsWebgltf()
+        {
+            return m_asWebgltf.Value;
+        }
+
+        private ICesiumValuePropertyWriter<CesiumResource> CreateWebgltfAdaptor()
+        {
+            return new CesiumWriterAdaptor<ModelUriCesiumWriter, CesiumResource>(
+                this, (me, value) => me.WriteWebgltf(value));
+        }
+
+        /// <summary>
+        /// Returns a wrapper for this instance that implements <see cref="ICesiumValuePropertyWriter{T}" /> to write a value in <code>Dae</code> format.  Because the returned instance is a wrapper for this instance, you may call <see cref="ICesiumElementWriter.Close" /> on either this instance or the wrapper, but you must not call it on both.
+        /// </summary>
+        /// <returns>The wrapper.</returns>
+        public ICesiumValuePropertyWriter<CesiumResource> AsDae()
+        {
+            return m_asDae.Value;
+        }
+
+        private ICesiumValuePropertyWriter<CesiumResource> CreateDaeAdaptor()
+        {
+            return new CesiumWriterAdaptor<ModelUriCesiumWriter, CesiumResource>(
+                this, (me, value) => me.WriteDae(value));
+        }
+
+    }
+}

--- a/DotNet/CesiumLanguageWriter/Generated/PacketCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PacketCesiumWriter.cs
@@ -93,6 +93,11 @@ namespace CesiumLanguageWriter
         /// </summary>
         public const string ViewFromPropertyName = "viewFrom";
 
+        /// <summary>
+        /// The name of the <code>model</code> property.
+        /// </summary>
+        public const string ModelPropertyName = "model";
+
         private readonly Lazy<PositionCesiumWriter> m_position = new Lazy<PositionCesiumWriter>(() => new PositionCesiumWriter(PositionPropertyName), false);
         private readonly Lazy<BillboardCesiumWriter> m_billboard = new Lazy<BillboardCesiumWriter>(() => new BillboardCesiumWriter(BillboardPropertyName), false);
         private readonly Lazy<PositionListCesiumWriter> m_vertexPositions = new Lazy<PositionListCesiumWriter>(() => new PositionListCesiumWriter(VertexPositionsPropertyName), false);
@@ -106,6 +111,7 @@ namespace CesiumLanguageWriter
         private readonly Lazy<PyramidCesiumWriter> m_pyramid = new Lazy<PyramidCesiumWriter>(() => new PyramidCesiumWriter(PyramidPropertyName), false);
         private readonly Lazy<CameraCesiumWriter> m_camera = new Lazy<CameraCesiumWriter>(() => new CameraCesiumWriter(CameraPropertyName), false);
         private readonly Lazy<EllipsoidCesiumWriter> m_ellipsoid = new Lazy<EllipsoidCesiumWriter>(() => new EllipsoidCesiumWriter(EllipsoidPropertyName), false);
+        private readonly Lazy<ModelCesiumWriter> m_model = new Lazy<ModelCesiumWriter>(() => new ModelCesiumWriter(ModelPropertyName), false);
 
         /// <summary>
         /// Writes the start of a new JSON object representing the packet.
@@ -615,6 +621,22 @@ namespace CesiumLanguageWriter
             const string PropertyName = ViewFromPropertyName;
             Output.WritePropertyName(PropertyName);
             CesiumWritingHelper.WriteCartesian3(Output, PropertyName, dates, values, startIndex, length);
+        }
+
+        /// <summary>
+        /// Gets the writer for the <code>model</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>model</code> property defines a 3D model.  The model is positioned and oriented using the `position` and `orientation` properties.
+        /// </summary>
+        public ModelCesiumWriter ModelWriter
+        {
+            get { return m_model.Value; }
+        }
+
+        /// <summary>
+        /// Opens and returns the writer for the <code>model</code> property.  The <code>model</code> property defines a 3D model.  The model is positioned and oriented using the `position` and `orientation` properties.
+        /// </summary>
+        public ModelCesiumWriter OpenModelProperty()
+        {
+            return OpenAndReturn(ModelWriter);
         }
 
     }

--- a/DotNet/GenerateFromSchema/GenerateCSharp.config.json
+++ b/DotNet/GenerateFromSchema/GenerateCSharp.config.json
@@ -299,6 +299,50 @@
                 "writeValue": "CesiumWritingHelper.WriteCartographicList(Output, values);"
             }
         ],
+        "ModelUri": [
+            {
+                "parameters": [
+                    {
+                        "type": "CesiumResource",
+                        "name": "resource",
+                        "description": "A resource object describing the model."
+                    }
+                ],
+				"callOverload": "resource.Url, resource.Behavior"
+            },
+			{
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "url",
+                        "description": "The URL of the model."
+                    },
+                    {
+                        "type": "CesiumResourceBehavior",
+                        "name": "resourceBehavior",
+                        "description": "An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver."
+                    }
+                ],
+                "writeValue": "Output.WriteValue(CesiumFormattingHelper.GetResourceUrl(url, resourceBehavior));",
+				"needsInterval": false
+            },
+            {
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "url",
+                        "description": "The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document."
+                    },
+                    {
+                        "type": "ICesiumUrlResolver",
+                        "name": "resolver",
+                        "description": "An ICesiumUrlResolver used to build the final URL that will be embedded in the document."
+                    }
+                ],
+                "writeValue": "Output.WriteValue(resolver.ResolveUrl(url));",
+				"needsInterval": false
+            },
+        ],
         "Image": [
             {
                 "parameters": [

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/GregorianDate.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/GregorianDate.java
@@ -2062,7 +2062,7 @@ public class GregorianDate implements Comparable<GregorianDate>, IEquatable<Greg
 	
 	
 
-	 * @param format The type of ISO9601 string to create.
+	 * @param format The type of ISO8601 string to create.
 	 * @return A string representing this date and time in ISO8601 format.
 	 */
 	public final String toIso8601String(Iso8601Format format) {

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ModelCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ModelCesiumWriter.java
@@ -1,0 +1,329 @@
+package cesiumlanguagewriter;
+
+
+import agi.foundation.compatibility.*;
+import agi.foundation.compatibility.DisposeHelper;
+import agi.foundation.compatibility.Func1;
+import agi.foundation.compatibility.Lazy;
+import cesiumlanguagewriter.advanced.*;
+import cesiumlanguagewriter.BooleanCesiumWriter;
+import cesiumlanguagewriter.DoubleCesiumWriter;
+import cesiumlanguagewriter.ModelUriCesiumWriter;
+import java.util.List;
+
+/**
+ *  
+ Writes a <code>Model</code> to a  {@link CesiumOutputStream}.  A <code>Model</code> defines a 3D model.
+ 
+
+ */
+public class ModelCesiumWriter extends CesiumPropertyWriter<ModelCesiumWriter> {
+	/**
+	 *  
+	The name of the <code>show</code> property.
+	
+
+	 */
+	public static final String ShowPropertyName = "show";
+	/**
+	 *  
+	The name of the <code>scale</code> property.
+	
+
+	 */
+	public static final String ScalePropertyName = "scale";
+	/**
+	 *  
+	The name of the <code>uri</code> property.
+	
+
+	 */
+	public static final String UriPropertyName = "uri";
+	private Lazy<BooleanCesiumWriter> m_show = new Lazy<cesiumlanguagewriter.BooleanCesiumWriter>(new Func1<cesiumlanguagewriter.BooleanCesiumWriter>() {
+		public cesiumlanguagewriter.BooleanCesiumWriter invoke() {
+			return new BooleanCesiumWriter(ShowPropertyName);
+		}
+	}, false);
+	private Lazy<DoubleCesiumWriter> m_scale = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
+		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
+			return new DoubleCesiumWriter(ScalePropertyName);
+		}
+	}, false);
+	private Lazy<ModelUriCesiumWriter> m_uri = new Lazy<cesiumlanguagewriter.ModelUriCesiumWriter>(new Func1<cesiumlanguagewriter.ModelUriCesiumWriter>() {
+		public cesiumlanguagewriter.ModelUriCesiumWriter invoke() {
+			return new ModelUriCesiumWriter(UriPropertyName);
+		}
+	}, false);
+
+	/**
+	 *  
+	Initializes a new instance.
+	
+
+	 */
+	public ModelCesiumWriter(String propertyName) {
+		super(propertyName);
+	}
+
+	/**
+	 *  
+	Initializes a new instance as a copy of an existing instance.
+	
+	
+
+	 * @param existingInstance The existing instance to copy.
+	 */
+	protected ModelCesiumWriter(ModelCesiumWriter existingInstance) {
+		super(existingInstance);
+	}
+
+	@Override
+	public ModelCesiumWriter clone() {
+		return new ModelCesiumWriter(this);
+	}
+
+	/**
+	 *  Gets the writer for the <code>show</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>show</code> property defines whether or not the model is shown.
+	
+
+	 */
+	public final BooleanCesiumWriter getShowWriter() {
+		return m_show.getValue();
+	}
+
+	/**
+	 *  
+	Opens and returns the writer for the <code>show</code> property.  The <code>show</code> property defines whether or not the model is shown.
+	
+
+	 */
+	public final BooleanCesiumWriter openShowProperty() {
+		openIntervalIfNecessary();
+		return this.<BooleanCesiumWriter> openAndReturn(getShowWriter());
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>show</code> property as a <code>boolean</code> value.  The <code>show</code> property specifies whether or not the model is shown.
+	
+	
+
+	 * @param value The value.
+	 */
+	public final void writeShowProperty(boolean value) {
+		{
+			cesiumlanguagewriter.BooleanCesiumWriter writer = openShowProperty();
+			try {
+				writer.writeBoolean(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  Gets the writer for the <code>scale</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>scale</code> property defines the scale of the model.
+	
+
+	 */
+	public final DoubleCesiumWriter getScaleWriter() {
+		return m_scale.getValue();
+	}
+
+	/**
+	 *  
+	Opens and returns the writer for the <code>scale</code> property.  The <code>scale</code> property defines the scale of the model.
+	
+
+	 */
+	public final DoubleCesiumWriter openScaleProperty() {
+		openIntervalIfNecessary();
+		return this.<DoubleCesiumWriter> openAndReturn(getScaleWriter());
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>scale</code> property as a <code>number</code> value.  The <code>scale</code> property specifies the scale of the model.
+	
+	
+
+	 * @param value The value.
+	 */
+	public final void writeScaleProperty(double value) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openScaleProperty();
+			try {
+				writer.writeNumber(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>scale</code> property as a <code>number</code> value.  The <code>scale</code> property specifies the scale of the model.
+	
+	
+	
+	
+	
+
+	 * @param dates The dates at which the value is specified.
+	 * @param values The value corresponding to each date.
+	 * @param startIndex The index of the first element to use in the `values` collection.
+	 * @param length The number of elements to use from the `values` collection.
+	 */
+	public final void writeScaleProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openScaleProperty();
+			try {
+				writer.writeNumber(dates, values, startIndex, length);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  Gets the writer for the <code>uri</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>uri</code> property defines the uri to the model.
+	
+
+	 */
+	public final ModelUriCesiumWriter getUriWriter() {
+		return m_uri.getValue();
+	}
+
+	/**
+	 *  
+	Opens and returns the writer for the <code>uri</code> property.  The <code>uri</code> property defines the uri to the model.
+	
+
+	 */
+	public final ModelUriCesiumWriter openUriProperty() {
+		openIntervalIfNecessary();
+		return this.<ModelUriCesiumWriter> openAndReturn(getUriWriter());
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>uri</code> property as a <code>webgltf</code> value.  The <code>uri</code> property specifies the uri to the model.
+	
+	
+
+	 * @param resource A resource object describing the model.
+	 */
+	public final void writeUriProperty(CesiumResource resource) {
+		{
+			cesiumlanguagewriter.ModelUriCesiumWriter writer = openUriProperty();
+			try {
+				writer.writeWebgltf(resource);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>uri</code> property as a <code>webgltf</code> value.  The <code>uri</code> property specifies the uri to the model.
+	
+	
+	
+
+	 * @param url The URL of the model.
+	 * @param resourceBehavior An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.
+	 */
+	public final void writeUriProperty(String url, CesiumResourceBehavior resourceBehavior) {
+		{
+			cesiumlanguagewriter.ModelUriCesiumWriter writer = openUriProperty();
+			try {
+				writer.writeWebgltf(url, resourceBehavior);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>uri</code> property as a <code>webgltf</code> value.  The <code>uri</code> property specifies the uri to the model.
+	
+	
+	
+
+	 * @param url The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.
+	 * @param resolver An ICesiumUrlResolver used to build the final URL that will be embedded in the document.
+	 */
+	public final void writeUriProperty(String url, ICesiumUrlResolver resolver) {
+		{
+			cesiumlanguagewriter.ModelUriCesiumWriter writer = openUriProperty();
+			try {
+				writer.writeWebgltf(url, resolver);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>uri</code> property as a <code>dae</code> value.  The <code>uri</code> property specifies the uri to the model.
+	
+	
+
+	 * @param resource A resource object describing the model.
+	 */
+	public final void writeUriPropertyDae(CesiumResource resource) {
+		{
+			cesiumlanguagewriter.ModelUriCesiumWriter writer = openUriProperty();
+			try {
+				writer.writeDae(resource);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>uri</code> property as a <code>dae</code> value.  The <code>uri</code> property specifies the uri to the model.
+	
+	
+	
+
+	 * @param url The URL of the model.
+	 * @param resourceBehavior An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.
+	 */
+	public final void writeUriPropertyDae(String url, CesiumResourceBehavior resourceBehavior) {
+		{
+			cesiumlanguagewriter.ModelUriCesiumWriter writer = openUriProperty();
+			try {
+				writer.writeDae(url, resourceBehavior);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>uri</code> property as a <code>dae</code> value.  The <code>uri</code> property specifies the uri to the model.
+	
+	
+	
+
+	 * @param url The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.
+	 * @param resolver An ICesiumUrlResolver used to build the final URL that will be embedded in the document.
+	 */
+	public final void writeUriPropertyDae(String url, ICesiumUrlResolver resolver) {
+		{
+			cesiumlanguagewriter.ModelUriCesiumWriter writer = openUriProperty();
+			try {
+				writer.writeDae(url, resolver);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ModelUriCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ModelUriCesiumWriter.java
@@ -1,0 +1,217 @@
+package cesiumlanguagewriter;
+
+
+import agi.foundation.compatibility.*;
+import agi.foundation.compatibility.Func1;
+import agi.foundation.compatibility.Lazy;
+import cesiumlanguagewriter.advanced.*;
+
+/**
+ *  
+ Writes a <code>ModelUri</code> to a  {@link CesiumOutputStream}.  A <code>ModelUri</code> defines a model associated with an element, which can optionally vary over time.  The model is specified as multiple URLs where each property maps to a different format.  The client can choose its best supported format from those provided.
+ 
+
+ */
+public class ModelUriCesiumWriter extends CesiumPropertyWriter<ModelUriCesiumWriter> {
+	/**
+	 *  
+	The name of the <code>webgltf</code> property.
+	
+
+	 */
+	public static final String WebgltfPropertyName = "webgltf";
+	/**
+	 *  
+	The name of the <code>dae</code> property.
+	
+
+	 */
+	public static final String DaePropertyName = "dae";
+	private Lazy<ICesiumValuePropertyWriter<CesiumResource>> m_asWebgltf;
+	private Lazy<ICesiumValuePropertyWriter<CesiumResource>> m_asDae;
+
+	/**
+	 *  
+	Initializes a new instance.
+	
+
+	 */
+	public ModelUriCesiumWriter(String propertyName) {
+		super(propertyName);
+		m_asWebgltf = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(this,
+				"createWebgltfAdaptor", new Class[] {}) {
+			public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource> invoke() {
+				return createWebgltfAdaptor();
+			}
+		}, false);
+		m_asDae = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(this,
+				"createDaeAdaptor", new Class[] {}) {
+			public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource> invoke() {
+				return createDaeAdaptor();
+			}
+		}, false);
+	}
+
+	/**
+	 *  
+	Initializes a new instance as a copy of an existing instance.
+	
+	
+
+	 * @param existingInstance The existing instance to copy.
+	 */
+	protected ModelUriCesiumWriter(ModelUriCesiumWriter existingInstance) {
+		super(existingInstance);
+		m_asWebgltf = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(this,
+				"createWebgltfAdaptor", new Class[] {}) {
+			public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource> invoke() {
+				return createWebgltfAdaptor();
+			}
+		}, false);
+		m_asDae = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource>>(this,
+				"createDaeAdaptor", new Class[] {}) {
+			public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<CesiumResource> invoke() {
+				return createDaeAdaptor();
+			}
+		}, false);
+	}
+
+	@Override
+	public ModelUriCesiumWriter clone() {
+		return new ModelUriCesiumWriter(this);
+	}
+
+	/**
+	 *  
+	Writes the <code>webgltf</code> property.  The <code>webgltf</code> property specifies the URL of a WebGLTF model.
+	
+	
+
+	 * @param resource A resource object describing the model.
+	 */
+	public final void writeWebgltf(CesiumResource resource) {
+		writeWebgltf(resource.getUrl(), resource.getBehavior());
+	}
+
+	/**
+	 *  
+	Writes the <code>webgltf</code> property.  The <code>webgltf</code> property specifies the URL of a WebGLTF model.
+	
+	
+	
+
+	 * @param url The URL of the model.
+	 * @param resourceBehavior An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.
+	 */
+	public final void writeWebgltf(String url, CesiumResourceBehavior resourceBehavior) {
+		String PropertyName = WebgltfPropertyName;
+		if (getIsInterval()) {
+			getOutput().writePropertyName(PropertyName);
+		}
+		getOutput().writeValue(CesiumFormattingHelper.getResourceUrl(url, resourceBehavior));
+	}
+
+	/**
+	 *  
+	Writes the <code>webgltf</code> property.  The <code>webgltf</code> property specifies the URL of a WebGLTF model.
+	
+	
+	
+
+	 * @param url The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.
+	 * @param resolver An ICesiumUrlResolver used to build the final URL that will be embedded in the document.
+	 */
+	public final void writeWebgltf(String url, ICesiumUrlResolver resolver) {
+		String PropertyName = WebgltfPropertyName;
+		if (getIsInterval()) {
+			getOutput().writePropertyName(PropertyName);
+		}
+		getOutput().writeValue(resolver.resolveUrl(url));
+	}
+
+	/**
+	 *  
+	Writes the <code>dae</code> property.  The <code>dae</code> property specifies the URL of a Collada model.
+	
+	
+
+	 * @param resource A resource object describing the model.
+	 */
+	public final void writeDae(CesiumResource resource) {
+		writeDae(resource.getUrl(), resource.getBehavior());
+	}
+
+	/**
+	 *  
+	Writes the <code>dae</code> property.  The <code>dae</code> property specifies the URL of a Collada model.
+	
+	
+	
+
+	 * @param url The URL of the model.
+	 * @param resourceBehavior An enumeration describing how to include the model in the document. For even more control, use the overload that takes a ICesiumUrlResolver.
+	 */
+	public final void writeDae(String url, CesiumResourceBehavior resourceBehavior) {
+		String PropertyName = DaePropertyName;
+		openIntervalIfNecessary();
+		getOutput().writePropertyName(PropertyName);
+		getOutput().writeValue(CesiumFormattingHelper.getResourceUrl(url, resourceBehavior));
+	}
+
+	/**
+	 *  
+	Writes the <code>dae</code> property.  The <code>dae</code> property specifies the URL of a Collada model.
+	
+	
+	
+
+	 * @param url The URL of the model.  The provided ICesiumUrlResolver will be used to build the final URL embedded in the document.
+	 * @param resolver An ICesiumUrlResolver used to build the final URL that will be embedded in the document.
+	 */
+	public final void writeDae(String url, ICesiumUrlResolver resolver) {
+		String PropertyName = DaePropertyName;
+		openIntervalIfNecessary();
+		getOutput().writePropertyName(PropertyName);
+		getOutput().writeValue(resolver.resolveUrl(url));
+	}
+
+	/**
+	 *  
+	Returns a wrapper for this instance that implements  {@link ICesiumValuePropertyWriter} to write a value in <code>Webgltf</code> format.  Because the returned instance is a wrapper for this instance, you may call  {@link ICesiumElementWriter#close} on either this instance or the wrapper, but you must not call it on both.
+	
+	
+
+	 * @return The wrapper.
+	 */
+	public final ICesiumValuePropertyWriter<CesiumResource> asWebgltf() {
+		return m_asWebgltf.getValue();
+	}
+
+	final private ICesiumValuePropertyWriter<CesiumResource> createWebgltfAdaptor() {
+		return new CesiumWriterAdaptor<ModelUriCesiumWriter, CesiumResource>(this, new CesiumWriterAdaptorWriteCallback<ModelUriCesiumWriter, CesiumResource>() {
+			public void invoke(ModelUriCesiumWriter me, CesiumResource value) {
+				me.writeWebgltf(value);
+			}
+		});
+	}
+
+	/**
+	 *  
+	Returns a wrapper for this instance that implements  {@link ICesiumValuePropertyWriter} to write a value in <code>Dae</code> format.  Because the returned instance is a wrapper for this instance, you may call  {@link ICesiumElementWriter#close} on either this instance or the wrapper, but you must not call it on both.
+	
+	
+
+	 * @return The wrapper.
+	 */
+	public final ICesiumValuePropertyWriter<CesiumResource> asDae() {
+		return m_asDae.getValue();
+	}
+
+	final private ICesiumValuePropertyWriter<CesiumResource> createDaeAdaptor() {
+		return new CesiumWriterAdaptor<ModelUriCesiumWriter, CesiumResource>(this, new CesiumWriterAdaptorWriteCallback<ModelUriCesiumWriter, CesiumResource>() {
+			public void invoke(ModelUriCesiumWriter me, CesiumResource value) {
+				me.writeDae(value);
+			}
+		});
+	}
+}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PacketCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PacketCesiumWriter.java
@@ -11,6 +11,7 @@ import cesiumlanguagewriter.CameraCesiumWriter;
 import cesiumlanguagewriter.ConeCesiumWriter;
 import cesiumlanguagewriter.EllipsoidCesiumWriter;
 import cesiumlanguagewriter.LabelCesiumWriter;
+import cesiumlanguagewriter.ModelCesiumWriter;
 import cesiumlanguagewriter.OrientationCesiumWriter;
 import cesiumlanguagewriter.PathCesiumWriter;
 import cesiumlanguagewriter.PointCesiumWriter;
@@ -140,6 +141,13 @@ public class PacketCesiumWriter extends CesiumElementWriter {
 
 	 */
 	public static final String ViewFromPropertyName = "viewFrom";
+	/**
+	 *  
+	The name of the <code>model</code> property.
+	
+
+	 */
+	public static final String ModelPropertyName = "model";
 	private Lazy<PositionCesiumWriter> m_position = new Lazy<cesiumlanguagewriter.PositionCesiumWriter>(new Func1<cesiumlanguagewriter.PositionCesiumWriter>() {
 		public cesiumlanguagewriter.PositionCesiumWriter invoke() {
 			return new PositionCesiumWriter(PositionPropertyName);
@@ -203,6 +211,11 @@ public class PacketCesiumWriter extends CesiumElementWriter {
 	private Lazy<EllipsoidCesiumWriter> m_ellipsoid = new Lazy<cesiumlanguagewriter.EllipsoidCesiumWriter>(new Func1<cesiumlanguagewriter.EllipsoidCesiumWriter>() {
 		public cesiumlanguagewriter.EllipsoidCesiumWriter invoke() {
 			return new EllipsoidCesiumWriter(EllipsoidPropertyName);
+		}
+	}, false);
+	private Lazy<ModelCesiumWriter> m_model = new Lazy<cesiumlanguagewriter.ModelCesiumWriter>(new Func1<cesiumlanguagewriter.ModelCesiumWriter>() {
+		public cesiumlanguagewriter.ModelCesiumWriter invoke() {
+			return new ModelCesiumWriter(ModelPropertyName);
 		}
 	}, false);
 
@@ -913,5 +926,24 @@ public class PacketCesiumWriter extends CesiumElementWriter {
 		String PropertyName = ViewFromPropertyName;
 		getOutput().writePropertyName(PropertyName);
 		CesiumWritingHelper.writeCartesian3(getOutput(), PropertyName, dates, values, startIndex, length);
+	}
+
+	/**
+	 *  Gets the writer for the <code>model</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>model</code> property defines a 3D model.  The model is positioned and oriented using the `position` and `orientation` properties.
+	
+
+	 */
+	public final ModelCesiumWriter getModelWriter() {
+		return m_model.getValue();
+	}
+
+	/**
+	 *  
+	Opens and returns the writer for the <code>model</code> property.  The <code>model</code> property defines a 3D model.  The model is positioned and oriented using the `position` and `orientation` properties.
+	
+
+	 */
+	public final ModelCesiumWriter openModelProperty() {
+		return this.<ModelCesiumWriter> openAndReturn(getModelWriter());
 	}
 }

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CachingCesiumUrlResolver.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CachingCesiumUrlResolver.java
@@ -125,7 +125,7 @@ public class CachingCesiumUrlResolver implements ICesiumUrlResolver {
 
 	static private class ThreadLocal_0 extends ThreadLocal<CachingCesiumUrlResolver> {
 		final protected CachingCesiumUrlResolver initialValue() {
-			return null;
+			return (CachingCesiumUrlResolver) null;
 		}
 	}
 }

--- a/Schema/Model.jsonschema
+++ b/Schema/Model.jsonschema
@@ -1,0 +1,20 @@
+{
+    "title": "Model",
+    "description": "Defines a 3D model.",
+    "type": ["array", "object"],
+    "items": { "$ref": "#" },
+    "properties": {
+        "show": {
+            "$ref": "Boolean.jsonschema",
+            "description": "Whether or not the model is shown."
+        },
+        "scale": {
+            "$ref": "Double.jsonschema",
+            "description": "The scale of the model."
+        },
+        "uri": {
+            "$ref": "ModelUri.jsonschema",
+            "description": "The uri to the model."
+        }
+    }
+}

--- a/Schema/ModelUri.jsonschema
+++ b/Schema/ModelUri.jsonschema
@@ -1,0 +1,18 @@
+{
+    "title": "ModelUri",
+    "description": "Defines a model associated with an element, which can optionally vary over time.  The model is specified as multiple URLs where each property maps to a different format.  The client can choose its best supported format from those provided.",
+    "type": ["array", "object"],
+    "items": { "$ref": "#" },
+    "properties": {
+        "webgltf": {
+            "$ref": "ModelUriValue.jsonschema",
+            "description": "The URL of a WebGLTF model.",
+            "czmlValue": true
+        },
+        "dae": {
+            "$ref": "ModelUriValue.jsonschema",
+            "description": "The URL of a Collada model.",
+            "czmlValue": true
+        }
+    }
+}

--- a/Schema/ModelUriValue.jsonschema
+++ b/Schema/ModelUriValue.jsonschema
@@ -1,0 +1,6 @@
+{
+    "title": "ModelUri",
+    "description": "The URI of the model.",
+    "type": "string",
+    "format": "uri"
+}

--- a/Schema/Packet.jsonschema
+++ b/Schema/Packet.jsonschema
@@ -73,5 +73,9 @@
             "$ref": "Cartesian3Value.jsonschema",
             "description": "A suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the objects position property."
         },
+        "model": {
+            "$ref": "Model.jsonschema",
+            "description": "A 3D model.  The model is positioned and oriented using the `position` and `orientation` properties."
+        },
     }
 }


### PR DESCRIPTION
Models still need to be implemented on the client side, but the CZML should be straight forward.  Here's an example of what this pull allows.

```
{
  "id" : "Vehicle",
   "position" : {
    "cartographicDegrees":[0.0,0.0,0.0]
  },
   "orientation" : {
    "unitQuaternion":[0.0,0.0,0.0,1.0]
  },
  "model" : {
     "show" : true,
     "scale" : 1000.0,
    "uri" : {
       "webgltf" : "myModel.json"
       "dae" : "myModel.dae"
    }
}
```

So `model` depends on `position` and `orientation`.  You can specify `show`, `scale`, and `uri`.  The first two are straightforward.  The only special thing about `uri` is that it allows multiple formats to be specified for the same model file (based on property name).  The client then selects the model file that it has the "best" support for.  This is similar to how HTML5 video works and allows CZML to be platform agnostic.
