### PR TITLE
Rename `bearing` to `rotation`

### DIFF
--- a/DotNet/CesiumLanguageWriter/Generated/EllipseCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/EllipseCesiumWriter.cs
@@ -23,13 +23,13 @@ namespace CesiumLanguageWriter
         public const string SemiMinorAxisPropertyName = "semiMinorAxis";
 
         /// <summary>
-        /// The name of the <code>bearing</code> property.
+        /// The name of the <code>rotation</code> property.
         /// </summary>
-        public const string BearingPropertyName = "bearing";
+        public const string RotationPropertyName = "rotation";
 
         private readonly Lazy<DoubleCesiumWriter> m_semiMajorAxis = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(SemiMajorAxisPropertyName), false);
         private readonly Lazy<DoubleCesiumWriter> m_semiMinorAxis = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(SemiMinorAxisPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_bearing = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(BearingPropertyName), false);
+        private readonly Lazy<DoubleCesiumWriter> m_rotation = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RotationPropertyName), false);
 
         /// <summary>
         /// Initializes a new instance.
@@ -143,44 +143,44 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Gets the writer for the <code>bearing</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>bearing</code> property defines the angle from north (clockwise) in radians.
+        /// Gets the writer for the <code>rotation</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>rotation</code> property defines the angle from north (clockwise) in radians.
         /// </summary>
-        public DoubleCesiumWriter BearingWriter
+        public DoubleCesiumWriter RotationWriter
         {
-            get { return m_bearing.Value; }
+            get { return m_rotation.Value; }
         }
 
         /// <summary>
-        /// Opens and returns the writer for the <code>bearing</code> property.  The <code>bearing</code> property defines the angle from north (clockwise) in radians.
+        /// Opens and returns the writer for the <code>rotation</code> property.  The <code>rotation</code> property defines the angle from north (clockwise) in radians.
         /// </summary>
-        public DoubleCesiumWriter OpenBearingProperty()
+        public DoubleCesiumWriter OpenRotationProperty()
         {
             OpenIntervalIfNecessary();
-            return OpenAndReturn(BearingWriter);
+            return OpenAndReturn(RotationWriter);
         }
 
         /// <summary>
-        /// Writes a value for the <code>bearing</code> property as a <code>number</code> value.  The <code>bearing</code> property specifies the angle from north (clockwise) in radians.
+        /// Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the angle from north (clockwise) in radians.
         /// </summary>
         /// <param name="value">The value.</param>
-        public void WriteBearingProperty(double value)
+        public void WriteRotationProperty(double value)
         {
-            using (var writer = OpenBearingProperty())
+            using (var writer = OpenRotationProperty())
             {
                 writer.WriteNumber(value);
             }
         }
 
         /// <summary>
-        /// Writes a value for the <code>bearing</code> property as a <code>number</code> value.  The <code>bearing</code> property specifies the angle from north (clockwise) in radians.
+        /// Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the angle from north (clockwise) in radians.
         /// </summary>
         /// <param name="dates">The dates at which the value is specified.</param>
         /// <param name="values">The value corresponding to each date.</param>
         /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
         /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteBearingProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
+        public void WriteRotationProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
         {
-            using (var writer = OpenBearingProperty())
+            using (var writer = OpenRotationProperty())
             {
                 writer.WriteNumber(dates, values, startIndex, length);
             }

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/EllipseCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/EllipseCesiumWriter.java
@@ -32,11 +32,11 @@ public class EllipseCesiumWriter extends CesiumPropertyWriter<EllipseCesiumWrite
 	public static final String SemiMinorAxisPropertyName = "semiMinorAxis";
 	/**
 	 *  
-	The name of the <code>bearing</code> property.
+	The name of the <code>rotation</code> property.
 	
 
 	 */
-	public static final String BearingPropertyName = "bearing";
+	public static final String RotationPropertyName = "rotation";
 	private Lazy<DoubleCesiumWriter> m_semiMajorAxis = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
 		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
 			return new DoubleCesiumWriter(SemiMajorAxisPropertyName);
@@ -47,9 +47,9 @@ public class EllipseCesiumWriter extends CesiumPropertyWriter<EllipseCesiumWrite
 			return new DoubleCesiumWriter(SemiMinorAxisPropertyName);
 		}
 	}, false);
-	private Lazy<DoubleCesiumWriter> m_bearing = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
+	private Lazy<DoubleCesiumWriter> m_rotation = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
 		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(BearingPropertyName);
+			return new DoubleCesiumWriter(RotationPropertyName);
 		}
 	}, false);
 
@@ -209,36 +209,36 @@ public class EllipseCesiumWriter extends CesiumPropertyWriter<EllipseCesiumWrite
 	}
 
 	/**
-	 *  Gets the writer for the <code>bearing</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>bearing</code> property defines the angle from north (clockwise) in radians.
+	 *  Gets the writer for the <code>rotation</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>rotation</code> property defines the angle from north (clockwise) in radians.
 	
 
 	 */
-	public final DoubleCesiumWriter getBearingWriter() {
-		return m_bearing.getValue();
+	public final DoubleCesiumWriter getRotationWriter() {
+		return m_rotation.getValue();
 	}
 
 	/**
 	 *  
-	Opens and returns the writer for the <code>bearing</code> property.  The <code>bearing</code> property defines the angle from north (clockwise) in radians.
+	Opens and returns the writer for the <code>rotation</code> property.  The <code>rotation</code> property defines the angle from north (clockwise) in radians.
 	
 
 	 */
-	public final DoubleCesiumWriter openBearingProperty() {
+	public final DoubleCesiumWriter openRotationProperty() {
 		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getBearingWriter());
+		return this.<DoubleCesiumWriter> openAndReturn(getRotationWriter());
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>bearing</code> property as a <code>number</code> value.  The <code>bearing</code> property specifies the angle from north (clockwise) in radians.
+	Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the angle from north (clockwise) in radians.
 	
 	
 
 	 * @param value The value.
 	 */
-	public final void writeBearingProperty(double value) {
+	public final void writeRotationProperty(double value) {
 		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openBearingProperty();
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openRotationProperty();
 			try {
 				writer.writeNumber(value);
 			} finally {
@@ -249,7 +249,7 @@ public class EllipseCesiumWriter extends CesiumPropertyWriter<EllipseCesiumWrite
 
 	/**
 	 *  
-	Writes a value for the <code>bearing</code> property as a <code>number</code> value.  The <code>bearing</code> property specifies the angle from north (clockwise) in radians.
+	Writes a value for the <code>rotation</code> property as a <code>number</code> value.  The <code>rotation</code> property specifies the angle from north (clockwise) in radians.
 	
 	
 	
@@ -261,9 +261,9 @@ public class EllipseCesiumWriter extends CesiumPropertyWriter<EllipseCesiumWrite
 	 * @param startIndex The index of the first element to use in the `values` collection.
 	 * @param length The number of elements to use from the `values` collection.
 	 */
-	public final void writeBearingProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
+	public final void writeRotationProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
 		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openBearingProperty();
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openRotationProperty();
 			try {
 				writer.writeNumber(dates, values, startIndex, length);
 			} finally {

--- a/Schema/Ellipse.jsonschema
+++ b/Schema/Ellipse.jsonschema
@@ -12,7 +12,7 @@
 		    "$ref": "Double.jsonschema",
             "description": "The length of the ellipse's semi-minor axis in meters."
 		},
-		"bearing":{
+		"rotation":{
 		    "$ref": "Double.jsonschema",
             "description": "The angle from north (clockwise) in radians."
 		}


### PR DESCRIPTION
...to be consistent with other `rotation` properties.
