### PR TITLE
Make materials more closely match Cesium

### DIFF
--- a/DotNet/CesiumLanguageWriter/Generated/GridMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/GridMaterialCesiumWriter.cs
@@ -24,43 +24,22 @@ namespace CesiumLanguageWriter
         public const string CellAlphaPropertyName = "cellAlpha";
 
         /// <summary>
-        /// The name of the <code>rowCount</code> property.
+        /// The name of the <code>lineCount</code> property.
         /// </summary>
-        public const string RowCountPropertyName = "rowCount";
+        public const string LineCountPropertyName = "lineCount";
 
         /// <summary>
-        /// The name of the <code>columnCount</code> property.
+        /// The name of the <code>lineThickness</code> property.
         /// </summary>
-        public const string ColumnCountPropertyName = "columnCount";
+        public const string LineThicknessPropertyName = "lineThickness";
 
         /// <summary>
-        /// The name of the <code>rowThickness</code> property.
+        /// The name of the <code>lineOffset</code> property.
         /// </summary>
-        public const string RowThicknessPropertyName = "rowThickness";
-
-        /// <summary>
-        /// The name of the <code>columnThickness</code> property.
-        /// </summary>
-        public const string ColumnThicknessPropertyName = "columnThickness";
-
-        /// <summary>
-        /// The name of the <code>rowOffset</code> property.
-        /// </summary>
-        public const string RowOffsetPropertyName = "rowOffset";
-
-        /// <summary>
-        /// The name of the <code>columnOffset</code> property.
-        /// </summary>
-        public const string ColumnOffsetPropertyName = "columnOffset";
+        public const string LineOffsetPropertyName = "lineOffset";
 
         private readonly Lazy<ColorCesiumWriter> m_color = new Lazy<ColorCesiumWriter>(() => new ColorCesiumWriter(ColorPropertyName), false);
         private readonly Lazy<DoubleCesiumWriter> m_cellAlpha = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(CellAlphaPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_rowCount = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RowCountPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_columnCount = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ColumnCountPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_rowThickness = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RowThicknessPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_columnThickness = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ColumnThicknessPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_rowOffset = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RowOffsetPropertyName), false);
-        private readonly Lazy<DoubleCesiumWriter> m_columnOffset = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(ColumnOffsetPropertyName), false);
 
         /// <summary>
         /// Initializes a new instance.
@@ -304,567 +283,141 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Gets the writer for the <code>rowCount</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>rowCount</code> property defines the number of horizontal grid lines.
-        /// </summary>
-        public DoubleCesiumWriter RowCountWriter
-        {
-            get { return m_rowCount.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>rowCount</code> property.  The <code>rowCount</code> property defines the number of horizontal grid lines.
-        /// </summary>
-        public DoubleCesiumWriter OpenRowCountProperty()
-        {
-            OpenIntervalIfNecessary();
-            return OpenAndReturn(RowCountWriter);
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowCount</code> property as a <code>number</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
+        /// Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
         /// </summary>
         /// <param name="value">The value.</param>
-        public void WriteRowCountProperty(double value)
+        public void WriteLineCount(Rectangular value)
         {
-            using (var writer = OpenRowCountProperty())
-            {
-                writer.WriteNumber(value);
-            }
+            const string PropertyName = LineCountPropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteCartesian2(Output, value);
         }
 
         /// <summary>
-        /// Writes a value for the <code>rowCount</code> property as a <code>number</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
+        /// Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
         /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        public void WriteLineCount(double x, double y)
+        {
+            WriteLineCount(new Rectangular(x, y));
+        }
+
+        /// <summary>
+        /// Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
+        public void WriteLineCount(IList<JulianDate> dates, IList<Rectangular> values)
+        {
+            WriteLineCount(dates, values, 0, dates.Count);
+        }
+
+        /// <summary>
+        /// Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
         /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
         /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteRowCountProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
+        public void WriteLineCount(IList<JulianDate> dates, IList<Rectangular> values, int startIndex, int length)
         {
-            using (var writer = OpenRowCountProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-        /// </summary>
-        /// <param name="value">The reference.</param>
-        public void WriteRowCountPropertyReference(Reference value)
-        {
-            using (var writer = OpenRowCountProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-        /// </summary>
-        /// <param name="value">The earliest date of the interval.</param>
-        public void WriteRowCountPropertyReference(string value)
-        {
-            using (var writer = OpenRowCountProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyName">The property on the referenced object.</param>
-        public void WriteRowCountPropertyReference(string identifier, string propertyName)
-        {
-            using (var writer = OpenRowCountProperty())
-            {
-                writer.WriteReference(identifier, propertyName);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
-        public void WriteRowCountPropertyReference(string identifier, string[] propertyNames)
-        {
-            using (var writer = OpenRowCountProperty())
-            {
-                writer.WriteReference(identifier, propertyNames);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>columnCount</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>columnCount</code> property defines the number of vertical grid lines.
-        /// </summary>
-        public DoubleCesiumWriter ColumnCountWriter
-        {
-            get { return m_columnCount.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>columnCount</code> property.  The <code>columnCount</code> property defines the number of vertical grid lines.
-        /// </summary>
-        public DoubleCesiumWriter OpenColumnCountProperty()
-        {
+            const string PropertyName = LineCountPropertyName;
             OpenIntervalIfNecessary();
-            return OpenAndReturn(ColumnCountWriter);
+            CesiumWritingHelper.WriteCartesian2(Output, PropertyName, dates, values, startIndex, length);
         }
 
         /// <summary>
-        /// Writes a value for the <code>columnCount</code> property as a <code>number</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
+        /// Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
         /// </summary>
         /// <param name="value">The value.</param>
-        public void WriteColumnCountProperty(double value)
+        public void WriteLineThickness(Rectangular value)
         {
-            using (var writer = OpenColumnCountProperty())
-            {
-                writer.WriteNumber(value);
-            }
+            const string PropertyName = LineThicknessPropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteCartesian2(Output, value);
         }
 
         /// <summary>
-        /// Writes a value for the <code>columnCount</code> property as a <code>number</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
+        /// Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
         /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        public void WriteLineThickness(double x, double y)
+        {
+            WriteLineThickness(new Rectangular(x, y));
+        }
+
+        /// <summary>
+        /// Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
+        public void WriteLineThickness(IList<JulianDate> dates, IList<Rectangular> values)
+        {
+            WriteLineThickness(dates, values, 0, dates.Count);
+        }
+
+        /// <summary>
+        /// Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
         /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
         /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteColumnCountProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
+        public void WriteLineThickness(IList<JulianDate> dates, IList<Rectangular> values, int startIndex, int length)
         {
-            using (var writer = OpenColumnCountProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-        /// </summary>
-        /// <param name="value">The reference.</param>
-        public void WriteColumnCountPropertyReference(Reference value)
-        {
-            using (var writer = OpenColumnCountProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-        /// </summary>
-        /// <param name="value">The earliest date of the interval.</param>
-        public void WriteColumnCountPropertyReference(string value)
-        {
-            using (var writer = OpenColumnCountProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyName">The property on the referenced object.</param>
-        public void WriteColumnCountPropertyReference(string identifier, string propertyName)
-        {
-            using (var writer = OpenColumnCountProperty())
-            {
-                writer.WriteReference(identifier, propertyName);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
-        public void WriteColumnCountPropertyReference(string identifier, string[] propertyNames)
-        {
-            using (var writer = OpenColumnCountProperty())
-            {
-                writer.WriteReference(identifier, propertyNames);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>rowThickness</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>rowThickness</code> property defines the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        public DoubleCesiumWriter RowThicknessWriter
-        {
-            get { return m_rowThickness.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>rowThickness</code> property.  The <code>rowThickness</code> property defines the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        public DoubleCesiumWriter OpenRowThicknessProperty()
-        {
+            const string PropertyName = LineThicknessPropertyName;
             OpenIntervalIfNecessary();
-            return OpenAndReturn(RowThicknessWriter);
+            CesiumWritingHelper.WriteCartesian2(Output, PropertyName, dates, values, startIndex, length);
         }
 
         /// <summary>
-        /// Writes a value for the <code>rowThickness</code> property as a <code>number</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
+        /// Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
         /// </summary>
         /// <param name="value">The value.</param>
-        public void WriteRowThicknessProperty(double value)
+        public void WriteLineOffset(Rectangular value)
         {
-            using (var writer = OpenRowThicknessProperty())
-            {
-                writer.WriteNumber(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowThickness</code> property as a <code>number</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteRowThicknessProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
-        {
-            using (var writer = OpenRowThicknessProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        /// <param name="value">The reference.</param>
-        public void WriteRowThicknessPropertyReference(Reference value)
-        {
-            using (var writer = OpenRowThicknessProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        /// <param name="value">The earliest date of the interval.</param>
-        public void WriteRowThicknessPropertyReference(string value)
-        {
-            using (var writer = OpenRowThicknessProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyName">The property on the referenced object.</param>
-        public void WriteRowThicknessPropertyReference(string identifier, string propertyName)
-        {
-            using (var writer = OpenRowThicknessProperty())
-            {
-                writer.WriteReference(identifier, propertyName);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
-        public void WriteRowThicknessPropertyReference(string identifier, string[] propertyNames)
-        {
-            using (var writer = OpenRowThicknessProperty())
-            {
-                writer.WriteReference(identifier, propertyNames);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>columnThickness</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>columnThickness</code> property defines the thickness of vertical grid lines, in pixels.
-        /// </summary>
-        public DoubleCesiumWriter ColumnThicknessWriter
-        {
-            get { return m_columnThickness.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>columnThickness</code> property.  The <code>columnThickness</code> property defines the thickness of vertical grid lines, in pixels.
-        /// </summary>
-        public DoubleCesiumWriter OpenColumnThicknessProperty()
-        {
+            const string PropertyName = LineOffsetPropertyName;
             OpenIntervalIfNecessary();
-            return OpenAndReturn(ColumnThicknessWriter);
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteCartesian2(Output, value);
         }
 
         /// <summary>
-        /// Writes a value for the <code>columnThickness</code> property as a <code>number</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
+        /// Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
         /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteColumnThicknessProperty(double value)
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        public void WriteLineOffset(double x, double y)
         {
-            using (var writer = OpenColumnThicknessProperty())
-            {
-                writer.WriteNumber(value);
-            }
+            WriteLineOffset(new Rectangular(x, y));
         }
 
         /// <summary>
-        /// Writes a value for the <code>columnThickness</code> property as a <code>number</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
+        /// Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
         /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
+        public void WriteLineOffset(IList<JulianDate> dates, IList<Rectangular> values)
+        {
+            WriteLineOffset(dates, values, 0, dates.Count);
+        }
+
+        /// <summary>
+        /// Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
         /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
         /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteColumnThicknessProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
+        public void WriteLineOffset(IList<JulianDate> dates, IList<Rectangular> values, int startIndex, int length)
         {
-            using (var writer = OpenColumnThicknessProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-        /// </summary>
-        /// <param name="value">The reference.</param>
-        public void WriteColumnThicknessPropertyReference(Reference value)
-        {
-            using (var writer = OpenColumnThicknessProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-        /// </summary>
-        /// <param name="value">The earliest date of the interval.</param>
-        public void WriteColumnThicknessPropertyReference(string value)
-        {
-            using (var writer = OpenColumnThicknessProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyName">The property on the referenced object.</param>
-        public void WriteColumnThicknessPropertyReference(string identifier, string propertyName)
-        {
-            using (var writer = OpenColumnThicknessProperty())
-            {
-                writer.WriteReference(identifier, propertyName);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
-        public void WriteColumnThicknessPropertyReference(string identifier, string[] propertyNames)
-        {
-            using (var writer = OpenColumnThicknessProperty())
-            {
-                writer.WriteReference(identifier, propertyNames);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>rowOffset</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>rowOffset</code> property defines the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        public DoubleCesiumWriter RowOffsetWriter
-        {
-            get { return m_rowOffset.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>rowOffset</code> property.  The <code>rowOffset</code> property defines the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        public DoubleCesiumWriter OpenRowOffsetProperty()
-        {
+            const string PropertyName = LineOffsetPropertyName;
             OpenIntervalIfNecessary();
-            return OpenAndReturn(RowOffsetWriter);
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowOffset</code> property as a <code>number</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteRowOffsetProperty(double value)
-        {
-            using (var writer = OpenRowOffsetProperty())
-            {
-                writer.WriteNumber(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowOffset</code> property as a <code>number</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteRowOffsetProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
-        {
-            using (var writer = OpenRowOffsetProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="value">The reference.</param>
-        public void WriteRowOffsetPropertyReference(Reference value)
-        {
-            using (var writer = OpenRowOffsetProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="value">The earliest date of the interval.</param>
-        public void WriteRowOffsetPropertyReference(string value)
-        {
-            using (var writer = OpenRowOffsetProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyName">The property on the referenced object.</param>
-        public void WriteRowOffsetPropertyReference(string identifier, string propertyName)
-        {
-            using (var writer = OpenRowOffsetProperty())
-            {
-                writer.WriteReference(identifier, propertyName);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
-        public void WriteRowOffsetPropertyReference(string identifier, string[] propertyNames)
-        {
-            using (var writer = OpenRowOffsetProperty())
-            {
-                writer.WriteReference(identifier, propertyNames);
-            }
-        }
-
-        /// <summary>
-        /// Gets the writer for the <code>columnOffset</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>columnOffset</code> property defines the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        public DoubleCesiumWriter ColumnOffsetWriter
-        {
-            get { return m_columnOffset.Value; }
-        }
-
-        /// <summary>
-        /// Opens and returns the writer for the <code>columnOffset</code> property.  The <code>columnOffset</code> property defines the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        public DoubleCesiumWriter OpenColumnOffsetProperty()
-        {
-            OpenIntervalIfNecessary();
-            return OpenAndReturn(ColumnOffsetWriter);
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnOffset</code> property as a <code>number</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteColumnOffsetProperty(double value)
-        {
-            using (var writer = OpenColumnOffsetProperty())
-            {
-                writer.WriteNumber(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnOffset</code> property as a <code>number</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="dates">The dates at which the value is specified.</param>
-        /// <param name="values">The value corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteColumnOffsetProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
-        {
-            using (var writer = OpenColumnOffsetProperty())
-            {
-                writer.WriteNumber(dates, values, startIndex, length);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="value">The reference.</param>
-        public void WriteColumnOffsetPropertyReference(Reference value)
-        {
-            using (var writer = OpenColumnOffsetProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="value">The earliest date of the interval.</param>
-        public void WriteColumnOffsetPropertyReference(string value)
-        {
-            using (var writer = OpenColumnOffsetProperty())
-            {
-                writer.WriteReference(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyName">The property on the referenced object.</param>
-        public void WriteColumnOffsetPropertyReference(string identifier, string propertyName)
-        {
-            using (var writer = OpenColumnOffsetProperty())
-            {
-                writer.WriteReference(identifier, propertyName);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-        /// </summary>
-        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
-        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
-        public void WriteColumnOffsetPropertyReference(string identifier, string[] propertyNames)
-        {
-            using (var writer = OpenColumnOffsetProperty())
-            {
-                writer.WriteReference(identifier, propertyNames);
-            }
+            CesiumWritingHelper.WriteCartesian2(Output, PropertyName, dates, values, startIndex, length);
         }
 
     }

--- a/DotNet/CesiumLanguageWriter/Generated/ImageMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ImageMaterialCesiumWriter.cs
@@ -4,6 +4,7 @@
 using CesiumLanguageWriter.Advanced;
 using System;
 using System.Drawing;
+using System.Collections.Generic;
 
 namespace CesiumLanguageWriter
 {
@@ -16,6 +17,11 @@ namespace CesiumLanguageWriter
         /// The name of the <code>image</code> property.
         /// </summary>
         public const string ImagePropertyName = "image";
+
+        /// <summary>
+        /// The name of the <code>repeat</code> property.
+        /// </summary>
+        public const string RepeatPropertyName = "repeat";
 
         private readonly Lazy<UriCesiumWriter> m_image = new Lazy<UriCesiumWriter>(() => new UriCesiumWriter(ImagePropertyName), false);
 
@@ -170,6 +176,52 @@ namespace CesiumLanguageWriter
             {
                 writer.WriteReference(identifier, propertyNames);
             }
+        }
+
+        /// <summary>
+        /// Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public void WriteRepeat(Rectangular value)
+        {
+            const string PropertyName = RepeatPropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteCartesian2(Output, value);
+        }
+
+        /// <summary>
+        /// Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+        /// </summary>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        public void WriteRepeat(double x, double y)
+        {
+            WriteRepeat(new Rectangular(x, y));
+        }
+
+        /// <summary>
+        /// Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
+        public void WriteRepeat(IList<JulianDate> dates, IList<Rectangular> values)
+        {
+            WriteRepeat(dates, values, 0, dates.Count);
+        }
+
+        /// <summary>
+        /// Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+        /// </summary>
+        /// <param name="dates">The dates at which the vector is specified.</param>
+        /// <param name="values">The values corresponding to each date.</param>
+        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
+        /// <param name="length">The number of elements to use from the `values` collection.</param>
+        public void WriteRepeat(IList<JulianDate> dates, IList<Rectangular> values, int startIndex, int length)
+        {
+            const string PropertyName = RepeatPropertyName;
+            OpenIntervalIfNecessary();
+            CesiumWritingHelper.WriteCartesian2(Output, PropertyName, dates, values, startIndex, length);
         }
 
     }

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/GridMaterialCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/GridMaterialCesiumWriter.java
@@ -34,46 +34,25 @@ public class GridMaterialCesiumWriter extends CesiumPropertyWriter<GridMaterialC
 	public static final String CellAlphaPropertyName = "cellAlpha";
 	/**
 	 *  
-	The name of the <code>rowCount</code> property.
+	The name of the <code>lineCount</code> property.
 	
 
 	 */
-	public static final String RowCountPropertyName = "rowCount";
+	public static final String LineCountPropertyName = "lineCount";
 	/**
 	 *  
-	The name of the <code>columnCount</code> property.
+	The name of the <code>lineThickness</code> property.
 	
 
 	 */
-	public static final String ColumnCountPropertyName = "columnCount";
+	public static final String LineThicknessPropertyName = "lineThickness";
 	/**
 	 *  
-	The name of the <code>rowThickness</code> property.
+	The name of the <code>lineOffset</code> property.
 	
 
 	 */
-	public static final String RowThicknessPropertyName = "rowThickness";
-	/**
-	 *  
-	The name of the <code>columnThickness</code> property.
-	
-
-	 */
-	public static final String ColumnThicknessPropertyName = "columnThickness";
-	/**
-	 *  
-	The name of the <code>rowOffset</code> property.
-	
-
-	 */
-	public static final String RowOffsetPropertyName = "rowOffset";
-	/**
-	 *  
-	The name of the <code>columnOffset</code> property.
-	
-
-	 */
-	public static final String ColumnOffsetPropertyName = "columnOffset";
+	public static final String LineOffsetPropertyName = "lineOffset";
 	private Lazy<ColorCesiumWriter> m_color = new Lazy<cesiumlanguagewriter.ColorCesiumWriter>(new Func1<cesiumlanguagewriter.ColorCesiumWriter>() {
 		public cesiumlanguagewriter.ColorCesiumWriter invoke() {
 			return new ColorCesiumWriter(ColorPropertyName);
@@ -82,36 +61,6 @@ public class GridMaterialCesiumWriter extends CesiumPropertyWriter<GridMaterialC
 	private Lazy<DoubleCesiumWriter> m_cellAlpha = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
 		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
 			return new DoubleCesiumWriter(CellAlphaPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_rowCount = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
-		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(RowCountPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_columnCount = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
-		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(ColumnCountPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_rowThickness = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
-		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(RowThicknessPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_columnThickness = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
-		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(ColumnThicknessPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_rowOffset = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
-		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(RowOffsetPropertyName);
-		}
-	}, false);
-	private Lazy<DoubleCesiumWriter> m_columnOffset = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
-		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
-			return new DoubleCesiumWriter(ColumnOffsetPropertyName);
 		}
 	}, false);
 
@@ -481,866 +430,191 @@ public class GridMaterialCesiumWriter extends CesiumPropertyWriter<GridMaterialC
 	}
 
 	/**
-	 *  Gets the writer for the <code>rowCount</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>rowCount</code> property defines the number of horizontal grid lines.
-	
-
-	 */
-	public final DoubleCesiumWriter getRowCountWriter() {
-		return m_rowCount.getValue();
-	}
-
-	/**
 	 *  
-	Opens and returns the writer for the <code>rowCount</code> property.  The <code>rowCount</code> property defines the number of horizontal grid lines.
-	
-
-	 */
-	public final DoubleCesiumWriter openRowCountProperty() {
-		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getRowCountWriter());
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowCount</code> property as a <code>number</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
+	Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
 	
 	
 
 	 * @param value The value.
 	 */
-	public final void writeRowCountProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowCountProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
+	public final void writeLineCount(Rectangular value) {
+		String PropertyName = LineCountPropertyName;
+		openIntervalIfNecessary();
+		getOutput().writePropertyName(PropertyName);
+		CesiumWritingHelper.writeCartesian2(getOutput(), value);
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>rowCount</code> property as a <code>number</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
+	Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
+	
+	
+	
+
+	 * @param x The X component.
+	 * @param y The Y component.
+	 */
+	public final void writeLineCount(double x, double y) {
+		writeLineCount(new Rectangular(x, y));
+	}
+
+	/**
+	 *  
+	Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
+	
+	
+	
+
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
+	 */
+	public final void writeLineCount(List<JulianDate> dates, List<Rectangular> values) {
+		writeLineCount(dates, values, 0, dates.size());
+	}
+
+	/**
+	 *  
+	Writes the <code>lineCount</code> property.  The <code>lineCount</code> property specifies the number of grid lines along each axis.
 	
 	
 	
 	
 	
 
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
 	 * @param startIndex The index of the first element to use in the `values` collection.
 	 * @param length The number of elements to use from the `values` collection.
 	 */
-	public final void writeRowCountProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowCountProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-	
-	
-
-	 * @param value The reference.
-	 */
-	public final void writeRowCountPropertyReference(Reference value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowCountProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-	
-	
-
-	 * @param value The earliest date of the interval.
-	 */
-	public final void writeRowCountPropertyReference(String value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowCountProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyName The property on the referenced object.
-	 */
-	public final void writeRowCountPropertyReference(String identifier, String propertyName) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowCountProperty();
-			try {
-				writer.writeReference(identifier, propertyName);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowCount</code> property as a <code>reference</code> value.  The <code>rowCount</code> property specifies the number of horizontal grid lines.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
-	 */
-	public final void writeRowCountPropertyReference(String identifier, String[] propertyNames) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowCountProperty();
-			try {
-				writer.writeReference(identifier, propertyNames);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>columnCount</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>columnCount</code> property defines the number of vertical grid lines.
-	
-
-	 */
-	public final DoubleCesiumWriter getColumnCountWriter() {
-		return m_columnCount.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>columnCount</code> property.  The <code>columnCount</code> property defines the number of vertical grid lines.
-	
-
-	 */
-	public final DoubleCesiumWriter openColumnCountProperty() {
+	public final void writeLineCount(List<JulianDate> dates, List<Rectangular> values, int startIndex, int length) {
+		String PropertyName = LineCountPropertyName;
 		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getColumnCountWriter());
+		CesiumWritingHelper.writeCartesian2(getOutput(), PropertyName, dates, values, startIndex, length);
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>columnCount</code> property as a <code>number</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
+	Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
 	
 	
 
 	 * @param value The value.
 	 */
-	public final void writeColumnCountProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnCountProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
+	public final void writeLineThickness(Rectangular value) {
+		String PropertyName = LineThicknessPropertyName;
+		openIntervalIfNecessary();
+		getOutput().writePropertyName(PropertyName);
+		CesiumWritingHelper.writeCartesian2(getOutput(), value);
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>columnCount</code> property as a <code>number</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
+	Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
+	
+	
+	
+
+	 * @param x The X component.
+	 * @param y The Y component.
+	 */
+	public final void writeLineThickness(double x, double y) {
+		writeLineThickness(new Rectangular(x, y));
+	}
+
+	/**
+	 *  
+	Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
+	
+	
+	
+
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
+	 */
+	public final void writeLineThickness(List<JulianDate> dates, List<Rectangular> values) {
+		writeLineThickness(dates, values, 0, dates.size());
+	}
+
+	/**
+	 *  
+	Writes the <code>lineThickness</code> property.  The <code>lineThickness</code> property specifies the thickness of grid lines along each axis, in pixels.
 	
 	
 	
 	
 	
 
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
 	 * @param startIndex The index of the first element to use in the `values` collection.
 	 * @param length The number of elements to use from the `values` collection.
 	 */
-	public final void writeColumnCountProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnCountProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-	
-	
-
-	 * @param value The reference.
-	 */
-	public final void writeColumnCountPropertyReference(Reference value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnCountProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-	
-	
-
-	 * @param value The earliest date of the interval.
-	 */
-	public final void writeColumnCountPropertyReference(String value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnCountProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyName The property on the referenced object.
-	 */
-	public final void writeColumnCountPropertyReference(String identifier, String propertyName) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnCountProperty();
-			try {
-				writer.writeReference(identifier, propertyName);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnCount</code> property as a <code>reference</code> value.  The <code>columnCount</code> property specifies the number of vertical grid lines.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
-	 */
-	public final void writeColumnCountPropertyReference(String identifier, String[] propertyNames) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnCountProperty();
-			try {
-				writer.writeReference(identifier, propertyNames);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>rowThickness</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>rowThickness</code> property defines the thickness of horizontal grid lines, in pixels.
-	
-
-	 */
-	public final DoubleCesiumWriter getRowThicknessWriter() {
-		return m_rowThickness.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>rowThickness</code> property.  The <code>rowThickness</code> property defines the thickness of horizontal grid lines, in pixels.
-	
-
-	 */
-	public final DoubleCesiumWriter openRowThicknessProperty() {
+	public final void writeLineThickness(List<JulianDate> dates, List<Rectangular> values, int startIndex, int length) {
+		String PropertyName = LineThicknessPropertyName;
 		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getRowThicknessWriter());
+		CesiumWritingHelper.writeCartesian2(getOutput(), PropertyName, dates, values, startIndex, length);
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>rowThickness</code> property as a <code>number</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
+	Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
 	
 	
 
 	 * @param value The value.
 	 */
-	public final void writeRowThicknessProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowThicknessProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowThickness</code> property as a <code>number</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeRowThicknessProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowThicknessProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-	
-	
-
-	 * @param value The reference.
-	 */
-	public final void writeRowThicknessPropertyReference(Reference value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowThicknessProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-	
-	
-
-	 * @param value The earliest date of the interval.
-	 */
-	public final void writeRowThicknessPropertyReference(String value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowThicknessProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyName The property on the referenced object.
-	 */
-	public final void writeRowThicknessPropertyReference(String identifier, String propertyName) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowThicknessProperty();
-			try {
-				writer.writeReference(identifier, propertyName);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowThickness</code> property as a <code>reference</code> value.  The <code>rowThickness</code> property specifies the thickness of horizontal grid lines, in pixels.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
-	 */
-	public final void writeRowThicknessPropertyReference(String identifier, String[] propertyNames) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowThicknessProperty();
-			try {
-				writer.writeReference(identifier, propertyNames);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>columnThickness</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>columnThickness</code> property defines the thickness of vertical grid lines, in pixels.
-	
-
-	 */
-	public final DoubleCesiumWriter getColumnThicknessWriter() {
-		return m_columnThickness.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>columnThickness</code> property.  The <code>columnThickness</code> property defines the thickness of vertical grid lines, in pixels.
-	
-
-	 */
-	public final DoubleCesiumWriter openColumnThicknessProperty() {
+	public final void writeLineOffset(Rectangular value) {
+		String PropertyName = LineOffsetPropertyName;
 		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getColumnThicknessWriter());
+		getOutput().writePropertyName(PropertyName);
+		CesiumWritingHelper.writeCartesian2(getOutput(), value);
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>columnThickness</code> property as a <code>number</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
+	Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
+	
 	
 	
 
-	 * @param value The value.
+	 * @param x The X component.
+	 * @param y The Y component.
 	 */
-	public final void writeColumnThicknessProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnThicknessProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
+	public final void writeLineOffset(double x, double y) {
+		writeLineOffset(new Rectangular(x, y));
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>columnThickness</code> property as a <code>number</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
+	Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
+	
+	
+	
+
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
+	 */
+	public final void writeLineOffset(List<JulianDate> dates, List<Rectangular> values) {
+		writeLineOffset(dates, values, 0, dates.size());
+	}
+
+	/**
+	 *  
+	Writes the <code>lineOffset</code> property.  The <code>lineOffset</code> property specifies the offset of grid lines along each axis, as a percentage from 0 to 1.
 	
 	
 	
 	
 	
 
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
 	 * @param startIndex The index of the first element to use in the `values` collection.
 	 * @param length The number of elements to use from the `values` collection.
 	 */
-	public final void writeColumnThicknessProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnThicknessProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-	
-	
-
-	 * @param value The reference.
-	 */
-	public final void writeColumnThicknessPropertyReference(Reference value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnThicknessProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-	
-	
-
-	 * @param value The earliest date of the interval.
-	 */
-	public final void writeColumnThicknessPropertyReference(String value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnThicknessProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyName The property on the referenced object.
-	 */
-	public final void writeColumnThicknessPropertyReference(String identifier, String propertyName) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnThicknessProperty();
-			try {
-				writer.writeReference(identifier, propertyName);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnThickness</code> property as a <code>reference</code> value.  The <code>columnThickness</code> property specifies the thickness of vertical grid lines, in pixels.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
-	 */
-	public final void writeColumnThicknessPropertyReference(String identifier, String[] propertyNames) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnThicknessProperty();
-			try {
-				writer.writeReference(identifier, propertyNames);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>rowOffset</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>rowOffset</code> property defines the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-
-	 */
-	public final DoubleCesiumWriter getRowOffsetWriter() {
-		return m_rowOffset.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>rowOffset</code> property.  The <code>rowOffset</code> property defines the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-
-	 */
-	public final DoubleCesiumWriter openRowOffsetProperty() {
+	public final void writeLineOffset(List<JulianDate> dates, List<Rectangular> values, int startIndex, int length) {
+		String PropertyName = LineOffsetPropertyName;
 		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getRowOffsetWriter());
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowOffset</code> property as a <code>number</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-	
-
-	 * @param value The value.
-	 */
-	public final void writeRowOffsetProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowOffsetProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowOffset</code> property as a <code>number</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeRowOffsetProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowOffsetProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-	
-
-	 * @param value The reference.
-	 */
-	public final void writeRowOffsetPropertyReference(Reference value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowOffsetProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-	
-
-	 * @param value The earliest date of the interval.
-	 */
-	public final void writeRowOffsetPropertyReference(String value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowOffsetProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyName The property on the referenced object.
-	 */
-	public final void writeRowOffsetPropertyReference(String identifier, String propertyName) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowOffsetProperty();
-			try {
-				writer.writeReference(identifier, propertyName);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>rowOffset</code> property as a <code>reference</code> value.  The <code>rowOffset</code> property specifies the offset of horizontal grid lines, as a percentage from 0 to 1.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
-	 */
-	public final void writeRowOffsetPropertyReference(String identifier, String[] propertyNames) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openRowOffsetProperty();
-			try {
-				writer.writeReference(identifier, propertyNames);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  Gets the writer for the <code>columnOffset</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>columnOffset</code> property defines the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-
-	 */
-	public final DoubleCesiumWriter getColumnOffsetWriter() {
-		return m_columnOffset.getValue();
-	}
-
-	/**
-	 *  
-	Opens and returns the writer for the <code>columnOffset</code> property.  The <code>columnOffset</code> property defines the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-
-	 */
-	public final DoubleCesiumWriter openColumnOffsetProperty() {
-		openIntervalIfNecessary();
-		return this.<DoubleCesiumWriter> openAndReturn(getColumnOffsetWriter());
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnOffset</code> property as a <code>number</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-	
-
-	 * @param value The value.
-	 */
-	public final void writeColumnOffsetProperty(double value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnOffsetProperty();
-			try {
-				writer.writeNumber(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnOffset</code> property as a <code>number</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the value is specified.
-	 * @param values The value corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeColumnOffsetProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnOffsetProperty();
-			try {
-				writer.writeNumber(dates, values, startIndex, length);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-	
-
-	 * @param value The reference.
-	 */
-	public final void writeColumnOffsetPropertyReference(Reference value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnOffsetProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-	
-
-	 * @param value The earliest date of the interval.
-	 */
-	public final void writeColumnOffsetPropertyReference(String value) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnOffsetProperty();
-			try {
-				writer.writeReference(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyName The property on the referenced object.
-	 */
-	public final void writeColumnOffsetPropertyReference(String identifier, String propertyName) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnOffsetProperty();
-			try {
-				writer.writeReference(identifier, propertyName);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>columnOffset</code> property as a <code>reference</code> value.  The <code>columnOffset</code> property specifies the offset of vertical grid lines, as a percentage from 0 to 1.
-	
-	
-	
-
-	 * @param identifier The identifier of the object which contains the referenced property.
-	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
-	 */
-	public final void writeColumnOffsetPropertyReference(String identifier, String[] propertyNames) {
-		{
-			cesiumlanguagewriter.DoubleCesiumWriter writer = openColumnOffsetProperty();
-			try {
-				writer.writeReference(identifier, propertyNames);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
+		CesiumWritingHelper.writeCartesian2(getOutput(), PropertyName, dates, values, startIndex, length);
 	}
 }

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ImageMaterialCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/ImageMaterialCesiumWriter.java
@@ -8,6 +8,7 @@ import agi.foundation.compatibility.Lazy;
 import cesiumlanguagewriter.advanced.*;
 import cesiumlanguagewriter.UriCesiumWriter;
 import java.awt.image.RenderedImage;
+import java.util.List;
 
 /**
  *  
@@ -23,6 +24,13 @@ public class ImageMaterialCesiumWriter extends CesiumPropertyWriter<ImageMateria
 
 	 */
 	public static final String ImagePropertyName = "image";
+	/**
+	 *  
+	The name of the <code>repeat</code> property.
+	
+
+	 */
+	public static final String RepeatPropertyName = "repeat";
 	private Lazy<UriCesiumWriter> m_image = new Lazy<cesiumlanguagewriter.UriCesiumWriter>(new Func1<cesiumlanguagewriter.UriCesiumWriter>() {
 		public cesiumlanguagewriter.UriCesiumWriter invoke() {
 			return new UriCesiumWriter(ImagePropertyName);
@@ -255,5 +263,68 @@ public class ImageMaterialCesiumWriter extends CesiumPropertyWriter<ImageMateria
 				DisposeHelper.dispose(writer);
 			}
 		}
+	}
+
+	/**
+	 *  
+	Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+	
+	
+
+	 * @param value The value.
+	 */
+	public final void writeRepeat(Rectangular value) {
+		String PropertyName = RepeatPropertyName;
+		openIntervalIfNecessary();
+		getOutput().writePropertyName(PropertyName);
+		CesiumWritingHelper.writeCartesian2(getOutput(), value);
+	}
+
+	/**
+	 *  
+	Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+	
+	
+	
+
+	 * @param x The X component.
+	 * @param y The Y component.
+	 */
+	public final void writeRepeat(double x, double y) {
+		writeRepeat(new Rectangular(x, y));
+	}
+
+	/**
+	 *  
+	Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+	
+	
+	
+
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
+	 */
+	public final void writeRepeat(List<JulianDate> dates, List<Rectangular> values) {
+		writeRepeat(dates, values, 0, dates.size());
+	}
+
+	/**
+	 *  
+	Writes the <code>repeat</code> property.  The <code>repeat</code> property specifies the numger of times the image repeats along each axis.
+	
+	
+	
+	
+	
+
+	 * @param dates The dates at which the vector is specified.
+	 * @param values The values corresponding to each date.
+	 * @param startIndex The index of the first element to use in the `values` collection.
+	 * @param length The number of elements to use from the `values` collection.
+	 */
+	public final void writeRepeat(List<JulianDate> dates, List<Rectangular> values, int startIndex, int length) {
+		String PropertyName = RepeatPropertyName;
+		openIntervalIfNecessary();
+		CesiumWritingHelper.writeCartesian2(getOutput(), PropertyName, dates, values, startIndex, length);
 	}
 }

--- a/Schema/GridMaterial.jsonschema
+++ b/Schema/GridMaterial.jsonschema
@@ -12,29 +12,17 @@
             "$ref": "Double.jsonschema",
             "description": "Alpha value for the space between grid lines.  This will be combined with the color alpha."
         },
-        "rowCount": {
-            "$ref": "Double.jsonschema",
-            "description": "The number of horizontal grid lines."
+        "lineCount": {
+            "$ref": "Cartesian2Value.jsonschema",
+            "description": "The number of grid lines along each axis."
         },
-        "columnCount": {
-            "$ref": "Double.jsonschema",
-            "description": "The number of vertical grid lines."
+        "lineThickness": {
+            "$ref": "Cartesian2Value.jsonschema",
+            "description": "The thickness of grid lines along each axis, in pixels."
         },
-        "rowThickness": {
-            "$ref": "Double.jsonschema",
-            "description": "The thickness of horizontal grid lines, in pixels."
-        },
-        "columnThickness": {
-            "$ref": "Double.jsonschema",
-            "description": "The thickness of vertical grid lines, in pixels."
-        },
-        "rowOffset": {
-            "$ref": "Double.jsonschema",
-            "description": "The offset of horizontal grid lines, as a percentage from 0 to 1."
-        },
-        "columnOffset": {
-            "$ref": "Double.jsonschema",
-            "description": "The offset of vertical grid lines, as a percentage from 0 to 1."
+        "lineOffset": {
+            "$ref": "Cartesian2Value.jsonschema",
+            "description": "The offset of grid lines along each axis, as a percentage from 0 to 1."
         }
     }
 }

--- a/Schema/ImageMaterial.jsonschema
+++ b/Schema/ImageMaterial.jsonschema
@@ -7,6 +7,10 @@
         "image": {
             "$ref": "Uri.jsonschema",
             "description": "The image to display on the surface."
+        },
+        "repeat": {
+            "$ref": "Cartesian2Value.jsonschema",
+            "description": "The numger of times the image repeats along each axis."
         }
     }
 }


### PR DESCRIPTION
Grid and Image materials split out Cartesian2 properties into multiple individual properties.  In practice this is not very useful and can bloat the size of the CZML if both are changing.  This change also makes it easier to implement in Cesium and gets rid of some workarounds we were currently using.
