### PR TITLE
Fix RectangularSensor schema

### DIFF
--- a/DotNet/CesiumLanguageWriter/Generated/RectangularSensorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/RectangularSensorCesiumWriter.cs
@@ -19,9 +19,14 @@ namespace CesiumLanguageWriter
         public const string ShowPropertyName = "show";
 
         /// <summary>
-        /// The name of the <code>directions</code> property.
+        /// The name of the <code>xHalfAngle</code> property.
         /// </summary>
-        public const string DirectionsPropertyName = "directions";
+        public const string XHalfAnglePropertyName = "xHalfAngle";
+
+        /// <summary>
+        /// The name of the <code>yHalfAngle</code> property.
+        /// </summary>
+        public const string YHalfAnglePropertyName = "yHalfAngle";
 
         /// <summary>
         /// The name of the <code>radius</code> property.
@@ -89,7 +94,8 @@ namespace CesiumLanguageWriter
         public const string PortionToDisplayPropertyName = "portionToDisplay";
 
         private readonly Lazy<BooleanCesiumWriter> m_show = new Lazy<BooleanCesiumWriter>(() => new BooleanCesiumWriter(ShowPropertyName), false);
-        private readonly Lazy<DirectionListCesiumWriter> m_directions = new Lazy<DirectionListCesiumWriter>(() => new DirectionListCesiumWriter(DirectionsPropertyName), false);
+        private readonly Lazy<DoubleCesiumWriter> m_xHalfAngle = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(XHalfAnglePropertyName), false);
+        private readonly Lazy<DoubleCesiumWriter> m_yHalfAngle = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(YHalfAnglePropertyName), false);
         private readonly Lazy<DoubleCesiumWriter> m_radius = new Lazy<DoubleCesiumWriter>(() => new DoubleCesiumWriter(RadiusPropertyName), false);
         private readonly Lazy<BooleanCesiumWriter> m_showIntersection = new Lazy<BooleanCesiumWriter>(() => new BooleanCesiumWriter(ShowIntersectionPropertyName), false);
         private readonly Lazy<ColorCesiumWriter> m_intersectionColor = new Lazy<ColorCesiumWriter>(() => new ColorCesiumWriter(IntersectionColorPropertyName), false);
@@ -157,55 +163,190 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Gets the writer for the <code>directions</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>directions</code> property defines the list of directions defining the pyramid.
+        /// Gets the writer for the <code>xHalfAngle</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>xHalfAngle</code> property defines the X half angle.
         /// </summary>
-        public DirectionListCesiumWriter DirectionsWriter
+        public DoubleCesiumWriter XHalfAngleWriter
         {
-            get { return m_directions.Value; }
+            get { return m_xHalfAngle.Value; }
         }
 
         /// <summary>
-        /// Opens and returns the writer for the <code>directions</code> property.  The <code>directions</code> property defines the list of directions defining the pyramid.
+        /// Opens and returns the writer for the <code>xHalfAngle</code> property.  The <code>xHalfAngle</code> property defines the X half angle.
         /// </summary>
-        public DirectionListCesiumWriter OpenDirectionsProperty()
+        public DoubleCesiumWriter OpenXHalfAngleProperty()
         {
             OpenIntervalIfNecessary();
-            return OpenAndReturn(DirectionsWriter);
+            return OpenAndReturn(XHalfAngleWriter);
         }
 
         /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>unitSpherical</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
+        /// Writes a value for the <code>xHalfAngle</code> property as a <code>number</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
         /// </summary>
-        /// <param name="values">The values.</param>
-        public void WriteDirectionsProperty(IEnumerable<UnitSpherical> values)
+        /// <param name="value">The value.</param>
+        public void WriteXHalfAngleProperty(double value)
         {
-            using (var writer = OpenDirectionsProperty())
+            using (var writer = OpenXHalfAngleProperty())
             {
-                writer.WriteUnitSpherical(values);
+                writer.WriteNumber(value);
             }
         }
 
         /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>spherical</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
+        /// Writes a value for the <code>xHalfAngle</code> property as a <code>number</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
         /// </summary>
-        /// <param name="values">The values.</param>
-        public void WriteDirectionsPropertySpherical(IEnumerable<Spherical> values)
+        /// <param name="dates">The dates at which the value is specified.</param>
+        /// <param name="values">The value corresponding to each date.</param>
+        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
+        /// <param name="length">The number of elements to use from the `values` collection.</param>
+        public void WriteXHalfAngleProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
         {
-            using (var writer = OpenDirectionsProperty())
+            using (var writer = OpenXHalfAngleProperty())
             {
-                writer.WriteSpherical(values);
+                writer.WriteNumber(dates, values, startIndex, length);
             }
         }
 
         /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>unitCartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
+        /// Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
         /// </summary>
-        /// <param name="values">The values.</param>
-        public void WriteDirectionsPropertyUnitCartesian(IEnumerable<UnitCartesian> values)
+        /// <param name="value">The reference.</param>
+        public void WriteXHalfAnglePropertyReference(Reference value)
         {
-            using (var writer = OpenDirectionsProperty())
+            using (var writer = OpenXHalfAngleProperty())
             {
-                writer.WriteUnitCartesian(values);
+                writer.WriteReference(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+        /// </summary>
+        /// <param name="value">The earliest date of the interval.</param>
+        public void WriteXHalfAnglePropertyReference(string value)
+        {
+            using (var writer = OpenXHalfAngleProperty())
+            {
+                writer.WriteReference(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyName">The property on the referenced object.</param>
+        public void WriteXHalfAnglePropertyReference(string identifier, string propertyName)
+        {
+            using (var writer = OpenXHalfAngleProperty())
+            {
+                writer.WriteReference(identifier, propertyName);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
+        public void WriteXHalfAnglePropertyReference(string identifier, string[] propertyNames)
+        {
+            using (var writer = OpenXHalfAngleProperty())
+            {
+                writer.WriteReference(identifier, propertyNames);
+            }
+        }
+
+        /// <summary>
+        /// Gets the writer for the <code>yHalfAngle</code> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <code>yHalfAngle</code> property defines the Y half angle.
+        /// </summary>
+        public DoubleCesiumWriter YHalfAngleWriter
+        {
+            get { return m_yHalfAngle.Value; }
+        }
+
+        /// <summary>
+        /// Opens and returns the writer for the <code>yHalfAngle</code> property.  The <code>yHalfAngle</code> property defines the Y half angle.
+        /// </summary>
+        public DoubleCesiumWriter OpenYHalfAngleProperty()
+        {
+            OpenIntervalIfNecessary();
+            return OpenAndReturn(YHalfAngleWriter);
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>yHalfAngle</code> property as a <code>number</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public void WriteYHalfAngleProperty(double value)
+        {
+            using (var writer = OpenYHalfAngleProperty())
+            {
+                writer.WriteNumber(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>yHalfAngle</code> property as a <code>number</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+        /// </summary>
+        /// <param name="dates">The dates at which the value is specified.</param>
+        /// <param name="values">The value corresponding to each date.</param>
+        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
+        /// <param name="length">The number of elements to use from the `values` collection.</param>
+        public void WriteYHalfAngleProperty(IList<JulianDate> dates, IList<double> values, int startIndex, int length)
+        {
+            using (var writer = OpenYHalfAngleProperty())
+            {
+                writer.WriteNumber(dates, values, startIndex, length);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+        /// </summary>
+        /// <param name="value">The reference.</param>
+        public void WriteYHalfAnglePropertyReference(Reference value)
+        {
+            using (var writer = OpenYHalfAngleProperty())
+            {
+                writer.WriteReference(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+        /// </summary>
+        /// <param name="value">The earliest date of the interval.</param>
+        public void WriteYHalfAnglePropertyReference(string value)
+        {
+            using (var writer = OpenYHalfAngleProperty())
+            {
+                writer.WriteReference(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyName">The property on the referenced object.</param>
+        public void WriteYHalfAnglePropertyReference(string identifier, string propertyName)
+        {
+            using (var writer = OpenYHalfAngleProperty())
+            {
+                writer.WriteReference(identifier, propertyName);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
+        public void WriteYHalfAnglePropertyReference(string identifier, string[] propertyNames)
+        {
+            using (var writer = OpenYHalfAngleProperty())
+            {
+                writer.WriteReference(identifier, propertyNames);
             }
         }
 

--- a/DotNet/GenerateFromSchema/CSharpGenerator.cs
+++ b/DotNet/GenerateFromSchema/CSharpGenerator.cs
@@ -54,9 +54,9 @@ namespace GenerateFromSchema
 
                 bool isInterpolatable = schema.Extends != null && schema.Extends.Name == "InterpolatableProperty";
                 if (isInterpolatable)
-                    writer.WriteLine("public class {0}CesiumWriter : CesiumInterpolatablePropertyWriter<{0}CesiumWriter>", schema.NameWithPascalCase);
+                    writer.WriteLine(m_configuration.Access + " class {0}CesiumWriter : CesiumInterpolatablePropertyWriter<{0}CesiumWriter>", schema.NameWithPascalCase);
                 else
-                    writer.WriteLine("public class {0}CesiumWriter : CesiumPropertyWriter<{0}CesiumWriter>", schema.NameWithPascalCase);
+                    writer.WriteLine(m_configuration.Access + " class {0}CesiumWriter : CesiumPropertyWriter<{0}CesiumWriter>", schema.NameWithPascalCase);
 
                 writer.OpenScope();
 
@@ -86,7 +86,7 @@ namespace GenerateFromSchema
                 writer.OpenScope();
 
                 WriteDescriptionAsClassSummary(writer, packetSchema);
-                writer.WriteLine("public class PacketCesiumWriter : CesiumElementWriter");
+                writer.WriteLine(m_configuration.Access + " class PacketCesiumWriter : CesiumElementWriter");
                 writer.OpenScope();
 
                 WritePropertyNameConstants(writer, packetSchema);
@@ -648,6 +648,9 @@ namespace GenerateFromSchema
         {
             [JsonProperty("namespace")]
             public string Namespace = null;
+
+            [JsonProperty("access")]
+            public string Access = null;
 
             [JsonProperty("lazyNamespace")]
             public string LazyNamespace = null;

--- a/DotNet/GenerateFromSchema/GenerateCSharp.config.json
+++ b/DotNet/GenerateFromSchema/GenerateCSharp.config.json
@@ -1,5 +1,6 @@
 ﻿{
     "namespace": "CesiumLanguageWriter",
+    "access": "public",
     "lazyNamespace": "System",
     "types": {
         "TimeIntervalCollection": [

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/RectangularSensorCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/RectangularSensorCesiumWriter.java
@@ -8,7 +8,6 @@ import agi.foundation.compatibility.Lazy;
 import cesiumlanguagewriter.advanced.*;
 import cesiumlanguagewriter.BooleanCesiumWriter;
 import cesiumlanguagewriter.ColorCesiumWriter;
-import cesiumlanguagewriter.DirectionListCesiumWriter;
 import cesiumlanguagewriter.DoubleCesiumWriter;
 import cesiumlanguagewriter.MaterialCesiumWriter;
 import cesiumlanguagewriter.SensorVolumePortionToDisplayCesiumWriter;
@@ -31,11 +30,18 @@ public class RectangularSensorCesiumWriter extends CesiumPropertyWriter<Rectangu
 	public static final String ShowPropertyName = "show";
 	/**
 	 *  
-	The name of the <code>directions</code> property.
+	The name of the <code>xHalfAngle</code> property.
 	
 
 	 */
-	public static final String DirectionsPropertyName = "directions";
+	public static final String XHalfAnglePropertyName = "xHalfAngle";
+	/**
+	 *  
+	The name of the <code>yHalfAngle</code> property.
+	
+
+	 */
+	public static final String YHalfAnglePropertyName = "yHalfAngle";
 	/**
 	 *  
 	The name of the <code>radius</code> property.
@@ -132,9 +138,14 @@ public class RectangularSensorCesiumWriter extends CesiumPropertyWriter<Rectangu
 			return new BooleanCesiumWriter(ShowPropertyName);
 		}
 	}, false);
-	private Lazy<DirectionListCesiumWriter> m_directions = new Lazy<cesiumlanguagewriter.DirectionListCesiumWriter>(new Func1<cesiumlanguagewriter.DirectionListCesiumWriter>() {
-		public cesiumlanguagewriter.DirectionListCesiumWriter invoke() {
-			return new DirectionListCesiumWriter(DirectionsPropertyName);
+	private Lazy<DoubleCesiumWriter> m_xHalfAngle = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
+		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
+			return new DoubleCesiumWriter(XHalfAnglePropertyName);
+		}
+	}, false);
+	private Lazy<DoubleCesiumWriter> m_yHalfAngle = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
+		public cesiumlanguagewriter.DoubleCesiumWriter invoke() {
+			return new DoubleCesiumWriter(YHalfAnglePropertyName);
 		}
 	}, false);
 	private Lazy<DoubleCesiumWriter> m_radius = new Lazy<cesiumlanguagewriter.DoubleCesiumWriter>(new Func1<cesiumlanguagewriter.DoubleCesiumWriter>() {
@@ -271,38 +282,38 @@ public class RectangularSensorCesiumWriter extends CesiumPropertyWriter<Rectangu
 	}
 
 	/**
-	 *  Gets the writer for the <code>directions</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>directions</code> property defines the list of directions defining the pyramid.
+	 *  Gets the writer for the <code>xHalfAngle</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>xHalfAngle</code> property defines the X half angle.
 	
 
 	 */
-	public final DirectionListCesiumWriter getDirectionsWriter() {
-		return m_directions.getValue();
+	public final DoubleCesiumWriter getXHalfAngleWriter() {
+		return m_xHalfAngle.getValue();
 	}
 
 	/**
 	 *  
-	Opens and returns the writer for the <code>directions</code> property.  The <code>directions</code> property defines the list of directions defining the pyramid.
+	Opens and returns the writer for the <code>xHalfAngle</code> property.  The <code>xHalfAngle</code> property defines the X half angle.
 	
 
 	 */
-	public final DirectionListCesiumWriter openDirectionsProperty() {
+	public final DoubleCesiumWriter openXHalfAngleProperty() {
 		openIntervalIfNecessary();
-		return this.<DirectionListCesiumWriter> openAndReturn(getDirectionsWriter());
+		return this.<DoubleCesiumWriter> openAndReturn(getXHalfAngleWriter());
 	}
 
 	/**
 	 *  
-	Writes a value for the <code>directions</code> property as a <code>unitSpherical</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
+	Writes a value for the <code>xHalfAngle</code> property as a <code>number</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
 	
 	
 
-	 * @param values The values.
+	 * @param value The value.
 	 */
-	public final void writeDirectionsProperty(Iterable<UnitSpherical> values) {
+	public final void writeXHalfAngleProperty(double value) {
 		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openXHalfAngleProperty();
 			try {
-				writer.writeUnitSpherical(values);
+				writer.writeNumber(value);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}
@@ -311,17 +322,23 @@ public class RectangularSensorCesiumWriter extends CesiumPropertyWriter<Rectangu
 
 	/**
 	 *  
-	Writes a value for the <code>directions</code> property as a <code>spherical</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
+	Writes a value for the <code>xHalfAngle</code> property as a <code>number</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+	
+	
+	
 	
 	
 
-	 * @param values The values.
+	 * @param dates The dates at which the value is specified.
+	 * @param values The value corresponding to each date.
+	 * @param startIndex The index of the first element to use in the `values` collection.
+	 * @param length The number of elements to use from the `values` collection.
 	 */
-	public final void writeDirectionsPropertySpherical(Iterable<Spherical> values) {
+	public final void writeXHalfAngleProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
 		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openXHalfAngleProperty();
 			try {
-				writer.writeSpherical(values);
+				writer.writeNumber(dates, values, startIndex, length);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}
@@ -330,17 +347,222 @@ public class RectangularSensorCesiumWriter extends CesiumPropertyWriter<Rectangu
 
 	/**
 	 *  
-	Writes a value for the <code>directions</code> property as a <code>unitCartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
+	Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
 	
 	
 
-	 * @param values The values.
+	 * @param value The reference.
 	 */
-	public final void writeDirectionsPropertyUnitCartesian(Iterable<UnitCartesian> values) {
+	public final void writeXHalfAnglePropertyReference(Reference value) {
 		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openXHalfAngleProperty();
 			try {
-				writer.writeUnitCartesian(values);
+				writer.writeReference(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+	
+	
+
+	 * @param value The earliest date of the interval.
+	 */
+	public final void writeXHalfAnglePropertyReference(String value) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openXHalfAngleProperty();
+			try {
+				writer.writeReference(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+	
+	
+	
+
+	 * @param identifier The identifier of the object which contains the referenced property.
+	 * @param propertyName The property on the referenced object.
+	 */
+	public final void writeXHalfAnglePropertyReference(String identifier, String propertyName) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openXHalfAngleProperty();
+			try {
+				writer.writeReference(identifier, propertyName);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>xHalfAngle</code> property as a <code>reference</code> value.  The <code>xHalfAngle</code> property specifies the X half angle.
+	
+	
+	
+
+	 * @param identifier The identifier of the object which contains the referenced property.
+	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
+	 */
+	public final void writeXHalfAnglePropertyReference(String identifier, String[] propertyNames) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openXHalfAngleProperty();
+			try {
+				writer.writeReference(identifier, propertyNames);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  Gets the writer for the <code>yHalfAngle</code> property.  The returned instance must be opened by calling the  {@link CesiumElementWriter#open} method before it can be used for writing.  The <code>yHalfAngle</code> property defines the Y half angle.
+	
+
+	 */
+	public final DoubleCesiumWriter getYHalfAngleWriter() {
+		return m_yHalfAngle.getValue();
+	}
+
+	/**
+	 *  
+	Opens and returns the writer for the <code>yHalfAngle</code> property.  The <code>yHalfAngle</code> property defines the Y half angle.
+	
+
+	 */
+	public final DoubleCesiumWriter openYHalfAngleProperty() {
+		openIntervalIfNecessary();
+		return this.<DoubleCesiumWriter> openAndReturn(getYHalfAngleWriter());
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>yHalfAngle</code> property as a <code>number</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+	
+	
+
+	 * @param value The value.
+	 */
+	public final void writeYHalfAngleProperty(double value) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openYHalfAngleProperty();
+			try {
+				writer.writeNumber(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>yHalfAngle</code> property as a <code>number</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+	
+	
+	
+	
+	
+
+	 * @param dates The dates at which the value is specified.
+	 * @param values The value corresponding to each date.
+	 * @param startIndex The index of the first element to use in the `values` collection.
+	 * @param length The number of elements to use from the `values` collection.
+	 */
+	public final void writeYHalfAngleProperty(List<JulianDate> dates, List<Double> values, int startIndex, int length) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openYHalfAngleProperty();
+			try {
+				writer.writeNumber(dates, values, startIndex, length);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+	
+	
+
+	 * @param value The reference.
+	 */
+	public final void writeYHalfAnglePropertyReference(Reference value) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openYHalfAngleProperty();
+			try {
+				writer.writeReference(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+	
+	
+
+	 * @param value The earliest date of the interval.
+	 */
+	public final void writeYHalfAnglePropertyReference(String value) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openYHalfAngleProperty();
+			try {
+				writer.writeReference(value);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+	
+	
+	
+
+	 * @param identifier The identifier of the object which contains the referenced property.
+	 * @param propertyName The property on the referenced object.
+	 */
+	public final void writeYHalfAnglePropertyReference(String identifier, String propertyName) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openYHalfAngleProperty();
+			try {
+				writer.writeReference(identifier, propertyName);
+			} finally {
+				DisposeHelper.dispose(writer);
+			}
+		}
+	}
+
+	/**
+	 *  
+	Writes a value for the <code>yHalfAngle</code> property as a <code>reference</code> value.  The <code>yHalfAngle</code> property specifies the Y half angle.
+	
+	
+	
+
+	 * @param identifier The identifier of the object which contains the referenced property.
+	 * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
+	 */
+	public final void writeYHalfAnglePropertyReference(String identifier, String[] propertyNames) {
+		{
+			cesiumlanguagewriter.DoubleCesiumWriter writer = openYHalfAngleProperty();
+			try {
+				writer.writeReference(identifier, propertyNames);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}

--- a/Schema/Extensions/AGI/RectangularSensor.jsonschema
+++ b/Schema/Extensions/AGI/RectangularSensor.jsonschema
@@ -9,9 +9,13 @@
             "$ref": "Boolean.jsonschema",
             "description": "Whether or not the pyramid is shown."
         },
-        "directions": {
-            "$ref": "DirectionList.jsonschema",
-            "description": "The list of directions defining the pyramid."
+        "xHalfAngle": {
+            "$ref": "Double.jsonschema",
+            "description": "The X half angle."
+        },
+        "yHalfAngle": {
+            "$ref": "Double.jsonschema",
+            "description": "The Y half angle."
         },
         "radius": {
             "$ref": "Double.jsonschema",


### PR DESCRIPTION
It should have individual x and y half-angle properties, not directions.

Also made it possible to control the access level of generated writers for embedding as private in a wrapper library.
