### PR TITLE
Fix typo in DirectionList.jsonschema

### DIFF
--- a/DotNet/CesiumLanguageWriter/Generated/CustomPatternSensorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/CustomPatternSensorCesiumWriter.cs
@@ -200,40 +200,12 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
         /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteDirectionsPropertyCartesian(Cartesian value)
+        /// <param name="values">The values.</param>
+        public void WriteDirectionsPropertyCartesian(IEnumerable<Cartesian> values)
         {
             using (var writer = OpenDirectionsProperty())
             {
-                writer.WriteCartesian(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
-        /// </summary>
-        /// <param name="dates">The dates at which the vector is specified.</param>
-        /// <param name="values">The values corresponding to each date.</param>
-        public void WriteDirectionsPropertyCartesian(IList<JulianDate> dates, IList<Cartesian> values)
-        {
-            using (var writer = OpenDirectionsProperty())
-            {
-                writer.WriteCartesian(dates, values);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
-        /// </summary>
-        /// <param name="dates">The dates at which the vector is specified.</param>
-        /// <param name="values">The values corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteDirectionsPropertyCartesian(IList<JulianDate> dates, IList<Cartesian> values, int startIndex, int length)
-        {
-            using (var writer = OpenDirectionsProperty())
-            {
-                writer.WriteCartesian(dates, values, startIndex, length);
+                writer.WriteCartesian(values);
             }
         }
 

--- a/DotNet/CesiumLanguageWriter/Generated/DirectionListCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/DirectionListCesiumWriter.cs
@@ -34,7 +34,7 @@ namespace CesiumLanguageWriter
 
         private readonly Lazy<ICesiumValuePropertyWriter<IEnumerable<Spherical>>> m_asSpherical;
         private readonly Lazy<ICesiumValuePropertyWriter<IEnumerable<UnitSpherical>>> m_asUnitSpherical;
-        private readonly Lazy<ICesiumInterpolatableValuePropertyWriter<Cartesian>> m_asCartesian;
+        private readonly Lazy<ICesiumValuePropertyWriter<IEnumerable<Cartesian>>> m_asCartesian;
         private readonly Lazy<ICesiumValuePropertyWriter<IEnumerable<UnitCartesian>>> m_asUnitCartesian;
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace CesiumLanguageWriter
         {
             m_asSpherical = new Lazy<ICesiumValuePropertyWriter<IEnumerable<Spherical>>>(CreateSphericalAdaptor, false);
             m_asUnitSpherical = new Lazy<ICesiumValuePropertyWriter<IEnumerable<UnitSpherical>>>(CreateUnitSphericalAdaptor, false);
-            m_asCartesian = new Lazy<ICesiumInterpolatableValuePropertyWriter<Cartesian>>(CreateCartesianAdaptor, false);
+            m_asCartesian = new Lazy<ICesiumValuePropertyWriter<IEnumerable<Cartesian>>>(CreateCartesianAdaptor, false);
             m_asUnitCartesian = new Lazy<ICesiumValuePropertyWriter<IEnumerable<UnitCartesian>>>(CreateUnitCartesianAdaptor, false);
         }
 
@@ -58,7 +58,7 @@ namespace CesiumLanguageWriter
         {
             m_asSpherical = new Lazy<ICesiumValuePropertyWriter<IEnumerable<Spherical>>>(CreateSphericalAdaptor, false);
             m_asUnitSpherical = new Lazy<ICesiumValuePropertyWriter<IEnumerable<UnitSpherical>>>(CreateUnitSphericalAdaptor, false);
-            m_asCartesian = new Lazy<ICesiumInterpolatableValuePropertyWriter<Cartesian>>(CreateCartesianAdaptor, false);
+            m_asCartesian = new Lazy<ICesiumValuePropertyWriter<IEnumerable<Cartesian>>>(CreateCartesianAdaptor, false);
             m_asUnitCartesian = new Lazy<ICesiumValuePropertyWriter<IEnumerable<UnitCartesian>>>(CreateUnitCartesianAdaptor, false);
         }
 
@@ -95,37 +95,13 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Writes the <code>cartesian</code> property.  The <code>cartesian</code> property specifies the list of directions represented as Cartesian `[X, Y, Z, X, Y, Z, ...]`
         /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteCartesian(Cartesian value)
+        /// <param name="values">The values.</param>
+        public void WriteCartesian(IEnumerable<Cartesian> values)
         {
             const string PropertyName = CartesianPropertyName;
             OpenIntervalIfNecessary();
             Output.WritePropertyName(PropertyName);
-            CesiumWritingHelper.WriteCartesian3(Output, value);
-        }
-
-        /// <summary>
-        /// Writes the <code>cartesian</code> property.  The <code>cartesian</code> property specifies the list of directions represented as Cartesian `[X, Y, Z, X, Y, Z, ...]`
-        /// </summary>
-        /// <param name="dates">The dates at which the vector is specified.</param>
-        /// <param name="values">The values corresponding to each date.</param>
-        public void WriteCartesian(IList<JulianDate> dates, IList<Cartesian> values)
-        {
-            WriteCartesian(dates, values, 0, dates.Count);
-        }
-
-        /// <summary>
-        /// Writes the <code>cartesian</code> property.  The <code>cartesian</code> property specifies the list of directions represented as Cartesian `[X, Y, Z, X, Y, Z, ...]`
-        /// </summary>
-        /// <param name="dates">The dates at which the vector is specified.</param>
-        /// <param name="values">The values corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteCartesian(IList<JulianDate> dates, IList<Cartesian> values, int startIndex, int length)
-        {
-            const string PropertyName = CartesianPropertyName;
-            OpenIntervalIfNecessary();
-            CesiumWritingHelper.WriteCartesian3(Output, PropertyName, dates, values, startIndex, length);
+            CesiumWritingHelper.WriteCartesian3List(Output, values);
         }
 
         /// <summary>
@@ -171,18 +147,18 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
-        /// Returns a wrapper for this instance that implements <see cref="ICesiumInterpolatableValuePropertyWriter{T}" /> to write a value in <code>Cartesian</code> format.  Because the returned instance is a wrapper for this instance, you may call <see cref="ICesiumElementWriter.Close" /> on either this instance or the wrapper, but you must not call it on both.
+        /// Returns a wrapper for this instance that implements <see cref="ICesiumValuePropertyWriter{T}" /> to write a value in <code>Cartesian</code> format.  Because the returned instance is a wrapper for this instance, you may call <see cref="ICesiumElementWriter.Close" /> on either this instance or the wrapper, but you must not call it on both.
         /// </summary>
         /// <returns>The wrapper.</returns>
-        public ICesiumInterpolatableValuePropertyWriter<Cartesian> AsCartesian()
+        public ICesiumValuePropertyWriter<IEnumerable<Cartesian>> AsCartesian()
         {
             return m_asCartesian.Value;
         }
 
-        private ICesiumInterpolatableValuePropertyWriter<Cartesian> CreateCartesianAdaptor()
+        private ICesiumValuePropertyWriter<IEnumerable<Cartesian>> CreateCartesianAdaptor()
         {
-            return new CesiumInterpolatableWriterAdaptor<DirectionListCesiumWriter, Cartesian>(
-                this, (me, value) => me.WriteCartesian(value), (DirectionListCesiumWriter me, IList<JulianDate> dates, IList<Cartesian> values, int startIndex, int length) => me.WriteCartesian(dates, values, startIndex, length));
+            return new CesiumWriterAdaptor<DirectionListCesiumWriter, IEnumerable<Cartesian>>(
+                this, (me, value) => me.WriteCartesian(value));
         }
 
         /// <summary>

--- a/DotNet/CesiumLanguageWriter/Generated/FanCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/FanCesiumWriter.cs
@@ -164,40 +164,12 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the fan.
         /// </summary>
-        /// <param name="value">The value.</param>
-        public void WriteDirectionsPropertyCartesian(Cartesian value)
+        /// <param name="values">The values.</param>
+        public void WriteDirectionsPropertyCartesian(IEnumerable<Cartesian> values)
         {
             using (var writer = OpenDirectionsProperty())
             {
-                writer.WriteCartesian(value);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the fan.
-        /// </summary>
-        /// <param name="dates">The dates at which the vector is specified.</param>
-        /// <param name="values">The values corresponding to each date.</param>
-        public void WriteDirectionsPropertyCartesian(IList<JulianDate> dates, IList<Cartesian> values)
-        {
-            using (var writer = OpenDirectionsProperty())
-            {
-                writer.WriteCartesian(dates, values);
-            }
-        }
-
-        /// <summary>
-        /// Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the fan.
-        /// </summary>
-        /// <param name="dates">The dates at which the vector is specified.</param>
-        /// <param name="values">The values corresponding to each date.</param>
-        /// <param name="startIndex">The index of the first element to use in the `values` collection.</param>
-        /// <param name="length">The number of elements to use from the `values` collection.</param>
-        public void WriteDirectionsPropertyCartesian(IList<JulianDate> dates, IList<Cartesian> values, int startIndex, int length)
-        {
-            using (var writer = OpenDirectionsProperty())
-            {
-                writer.WriteCartesian(dates, values, startIndex, length);
+                writer.WriteCartesian(values);
             }
         }
 

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/CustomPatternSensorCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/CustomPatternSensorCesiumWriter.java
@@ -334,59 +334,13 @@ public class CustomPatternSensorCesiumWriter extends CesiumPropertyWriter<Custom
 	
 	
 
-	 * @param value The value.
+	 * @param values The values.
 	 */
-	public final void writeDirectionsPropertyCartesian(Cartesian value) {
+	public final void writeDirectionsPropertyCartesian(Iterable<Cartesian> values) {
 		{
 			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
 			try {
-				writer.writeCartesian(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
-	
-	
-	
-
-	 * @param dates The dates at which the vector is specified.
-	 * @param values The values corresponding to each date.
-	 */
-	public final void writeDirectionsPropertyCartesian(List<JulianDate> dates, List<Cartesian> values) {
-		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
-			try {
-				writer.writeCartesian(dates, values);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the pyramid.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the vector is specified.
-	 * @param values The values corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeDirectionsPropertyCartesian(List<JulianDate> dates, List<Cartesian> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
-			try {
-				writer.writeCartesian(dates, values, startIndex, length);
+				writer.writeCartesian(values);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/DirectionListCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/DirectionListCesiumWriter.java
@@ -5,8 +5,6 @@ import agi.foundation.compatibility.*;
 import agi.foundation.compatibility.Func1;
 import agi.foundation.compatibility.Lazy;
 import cesiumlanguagewriter.advanced.*;
-import cesiumlanguagewriter.Cartesian;
-import java.util.List;
 
 /**
  *  
@@ -45,7 +43,7 @@ public class DirectionListCesiumWriter extends CesiumPropertyWriter<DirectionLis
 	public static final String UnitCartesianPropertyName = "unitCartesian";
 	private Lazy<ICesiumValuePropertyWriter<Iterable<Spherical>>> m_asSpherical;
 	private Lazy<ICesiumValuePropertyWriter<Iterable<UnitSpherical>>> m_asUnitSpherical;
-	private Lazy<ICesiumInterpolatableValuePropertyWriter<Cartesian>> m_asCartesian;
+	private Lazy<ICesiumValuePropertyWriter<Iterable<Cartesian>>> m_asCartesian;
 	private Lazy<ICesiumValuePropertyWriter<Iterable<UnitCartesian>>> m_asUnitCartesian;
 
 	/**
@@ -68,9 +66,9 @@ public class DirectionListCesiumWriter extends CesiumPropertyWriter<DirectionLis
 						return createUnitSphericalAdaptor();
 					}
 				}, false);
-		m_asCartesian = new Lazy<cesiumlanguagewriter.advanced.ICesiumInterpolatableValuePropertyWriter<Cartesian>>(
-				new Func1<cesiumlanguagewriter.advanced.ICesiumInterpolatableValuePropertyWriter<Cartesian>>(this, "createCartesianAdaptor", new Class[] {}) {
-					public cesiumlanguagewriter.advanced.ICesiumInterpolatableValuePropertyWriter<Cartesian> invoke() {
+		m_asCartesian = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Iterable<Cartesian>>>(
+				new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Iterable<Cartesian>>>(this, "createCartesianAdaptor", new Class[] {}) {
+					public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Iterable<Cartesian>> invoke() {
 						return createCartesianAdaptor();
 					}
 				}, false);
@@ -104,9 +102,9 @@ public class DirectionListCesiumWriter extends CesiumPropertyWriter<DirectionLis
 						return createUnitSphericalAdaptor();
 					}
 				}, false);
-		m_asCartesian = new Lazy<cesiumlanguagewriter.advanced.ICesiumInterpolatableValuePropertyWriter<Cartesian>>(
-				new Func1<cesiumlanguagewriter.advanced.ICesiumInterpolatableValuePropertyWriter<Cartesian>>(this, "createCartesianAdaptor", new Class[] {}) {
-					public cesiumlanguagewriter.advanced.ICesiumInterpolatableValuePropertyWriter<Cartesian> invoke() {
+		m_asCartesian = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Iterable<Cartesian>>>(
+				new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Iterable<Cartesian>>>(this, "createCartesianAdaptor", new Class[] {}) {
+					public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Iterable<Cartesian>> invoke() {
 						return createCartesianAdaptor();
 					}
 				}, false);
@@ -159,47 +157,13 @@ public class DirectionListCesiumWriter extends CesiumPropertyWriter<DirectionLis
 	
 	
 
-	 * @param value The value.
+	 * @param values The values.
 	 */
-	public final void writeCartesian(Cartesian value) {
+	public final void writeCartesian(Iterable<Cartesian> values) {
 		String PropertyName = CartesianPropertyName;
 		openIntervalIfNecessary();
 		getOutput().writePropertyName(PropertyName);
-		CesiumWritingHelper.writeCartesian3(getOutput(), value);
-	}
-
-	/**
-	 *  
-	Writes the <code>cartesian</code> property.  The <code>cartesian</code> property specifies the list of directions represented as Cartesian `[X, Y, Z, X, Y, Z, ...]`
-	
-	
-	
-
-	 * @param dates The dates at which the vector is specified.
-	 * @param values The values corresponding to each date.
-	 */
-	public final void writeCartesian(List<JulianDate> dates, List<Cartesian> values) {
-		writeCartesian(dates, values, 0, dates.size());
-	}
-
-	/**
-	 *  
-	Writes the <code>cartesian</code> property.  The <code>cartesian</code> property specifies the list of directions represented as Cartesian `[X, Y, Z, X, Y, Z, ...]`
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the vector is specified.
-	 * @param values The values corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeCartesian(List<JulianDate> dates, List<Cartesian> values, int startIndex, int length) {
-		String PropertyName = CartesianPropertyName;
-		openIntervalIfNecessary();
-		CesiumWritingHelper.writeCartesian3(getOutput(), PropertyName, dates, values, startIndex, length);
+		CesiumWritingHelper.writeCartesian3List(getOutput(), values);
 	}
 
 	/**
@@ -261,25 +225,21 @@ public class DirectionListCesiumWriter extends CesiumPropertyWriter<DirectionLis
 
 	/**
 	 *  
-	Returns a wrapper for this instance that implements  {@link ICesiumInterpolatableValuePropertyWriter} to write a value in <code>Cartesian</code> format.  Because the returned instance is a wrapper for this instance, you may call  {@link ICesiumElementWriter#close} on either this instance or the wrapper, but you must not call it on both.
+	Returns a wrapper for this instance that implements  {@link ICesiumValuePropertyWriter} to write a value in <code>Cartesian</code> format.  Because the returned instance is a wrapper for this instance, you may call  {@link ICesiumElementWriter#close} on either this instance or the wrapper, but you must not call it on both.
 	
 	
 
 	 * @return The wrapper.
 	 */
-	public final ICesiumInterpolatableValuePropertyWriter<Cartesian> asCartesian() {
+	public final ICesiumValuePropertyWriter<Iterable<Cartesian>> asCartesian() {
 		return m_asCartesian.getValue();
 	}
 
-	final private ICesiumInterpolatableValuePropertyWriter<Cartesian> createCartesianAdaptor() {
-		return new CesiumInterpolatableWriterAdaptor<cesiumlanguagewriter.DirectionListCesiumWriter, cesiumlanguagewriter.Cartesian>(this,
-				new CesiumWriterAdaptorWriteCallback<cesiumlanguagewriter.DirectionListCesiumWriter, cesiumlanguagewriter.Cartesian>() {
-					public void invoke(DirectionListCesiumWriter me, Cartesian value) {
+	final private ICesiumValuePropertyWriter<Iterable<Cartesian>> createCartesianAdaptor() {
+		return new CesiumWriterAdaptor<cesiumlanguagewriter.DirectionListCesiumWriter, Iterable<Cartesian>>(this,
+				new CesiumWriterAdaptorWriteCallback<cesiumlanguagewriter.DirectionListCesiumWriter, Iterable<Cartesian>>() {
+					public void invoke(DirectionListCesiumWriter me, Iterable<Cartesian> value) {
 						me.writeCartesian(value);
-					}
-				}, new CesiumWriterAdaptorWriteSamplesCallback<cesiumlanguagewriter.DirectionListCesiumWriter, cesiumlanguagewriter.Cartesian>() {
-					public void invoke(DirectionListCesiumWriter me, List<JulianDate> dates, List<Cartesian> values, int startIndex, int length) {
-						me.writeCartesian(dates, values, startIndex, length);
 					}
 				});
 	}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/FanCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/FanCesiumWriter.java
@@ -260,59 +260,13 @@ public class FanCesiumWriter extends CesiumPropertyWriter<FanCesiumWriter> {
 	
 	
 
-	 * @param value The value.
+	 * @param values The values.
 	 */
-	public final void writeDirectionsPropertyCartesian(Cartesian value) {
+	public final void writeDirectionsPropertyCartesian(Iterable<Cartesian> values) {
 		{
 			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
 			try {
-				writer.writeCartesian(value);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the fan.
-	
-	
-	
-
-	 * @param dates The dates at which the vector is specified.
-	 * @param values The values corresponding to each date.
-	 */
-	public final void writeDirectionsPropertyCartesian(List<JulianDate> dates, List<Cartesian> values) {
-		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
-			try {
-				writer.writeCartesian(dates, values);
-			} finally {
-				DisposeHelper.dispose(writer);
-			}
-		}
-	}
-
-	/**
-	 *  
-	Writes a value for the <code>directions</code> property as a <code>cartesian</code> value.  The <code>directions</code> property specifies the list of directions defining the fan.
-	
-	
-	
-	
-	
-
-	 * @param dates The dates at which the vector is specified.
-	 * @param values The values corresponding to each date.
-	 * @param startIndex The index of the first element to use in the `values` collection.
-	 * @param length The number of elements to use from the `values` collection.
-	 */
-	public final void writeDirectionsPropertyCartesian(List<JulianDate> dates, List<Cartesian> values, int startIndex, int length) {
-		{
-			cesiumlanguagewriter.DirectionListCesiumWriter writer = openDirectionsProperty();
-			try {
-				writer.writeCartesian(dates, values, startIndex, length);
+				writer.writeCartesian(values);
 			} finally {
 				DisposeHelper.dispose(writer);
 			}

--- a/Schema/DirectionList.jsonschema
+++ b/Schema/DirectionList.jsonschema
@@ -15,7 +15,7 @@
             "czmlValue": true
         },
         "cartesian": {
-            "$ref": "Cartesian3Value.jsonschema",
+            "$ref": "Cartesian3ListValue.jsonschema",
             "description": "The list of directions represented as Cartesian `[X, Y, Z, X, Y, Z, ...]`",
             "czmlValue": true
         },


### PR DESCRIPTION
This caused a compile failure in the generated schema (how we didn't catch this before it went into master, I have no idea).
