### PR TITLE
Add ForceInterval flag to writers.

### DIFF
--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumFormattingHelper.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumFormattingHelper.cs
@@ -12,8 +12,8 @@ namespace CesiumLanguageWriter.Advanced
     /// </summary>
     public static class CesiumFormattingHelper
     {
-        static private JulianDate s_minimumGregorianDate = GregorianDate.MinValue.ToJulianDate();
-        static private JulianDate s_maximumGregorianDate = GregorianDate.MaxValue.ToJulianDate();
+        private static readonly JulianDate s_minimumGregorianDate = GregorianDate.MinValue.ToJulianDate();
+        private static readonly JulianDate s_maximumGregorianDate = GregorianDate.MaxValue.ToJulianDate();
 
         /// <summary>
         /// Converts a <see cref="TimeInterval"/> as an ISO8601 interval string.

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumInterpolatableWriterAdaptor.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumInterpolatableWriterAdaptor.cs
@@ -25,7 +25,7 @@ namespace CesiumLanguageWriter.Advanced
     /// <typeparam name="TFrom">The class derived from <see cref="CesiumInterpolatablePropertyWriter{TDerived}"/> to adapt.</typeparam>
     /// <typeparam name="TValue">The type of value to which to adapt the class to write.</typeparam>
     public class CesiumInterpolatableWriterAdaptor<TFrom, TValue> : ICesiumInterpolatableValuePropertyWriter<TValue>
-        where TFrom : ICesiumPropertyWriter, ICesiumInterpolationInformationWriter
+        where TFrom : class, ICesiumPropertyWriter, ICesiumInterpolationInformationWriter
     {
         private readonly TFrom m_parent;
         private readonly CesiumWriterAdaptorWriteCallback<TFrom, TValue> m_writeValueCallback;
@@ -157,6 +157,13 @@ namespace CesiumLanguageWriter.Advanced
         public ICesiumPropertyWriter IntervalWriter
         {
             get { return m_interval.Value; }
+        }
+
+        /// <inheritdoc />
+        public bool ForceInterval
+        {
+            get { return m_parent.ForceInterval; }
+            set { m_parent.ForceInterval = value; }
         }
 
         /// <inheritdoc />

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumPropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumPropertyWriter.cs
@@ -75,6 +75,11 @@ namespace CesiumLanguageWriter.Advanced
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this instance should always open an interval.
+        /// </summary>
+        public bool ForceInterval { get; set; }
+
+        /// <summary>
         /// Copies this instance and returns the copy.
         /// </summary>
         /// <returns>The copy.</returns>

--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumWriterAdaptor.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumWriterAdaptor.cs
@@ -21,7 +21,7 @@ namespace CesiumLanguageWriter.Advanced
     /// <typeparam name="TFrom">The class derived from <see cref="CesiumPropertyWriter{TDerived}"/> to adapt.</typeparam>
     /// <typeparam name="TValue">The type of value to which to adapt the class to write.</typeparam>
     public class CesiumWriterAdaptor<TFrom, TValue> : ICesiumValuePropertyWriter<TValue>
-        where TFrom : ICesiumPropertyWriter
+        where TFrom : class, ICesiumPropertyWriter
     {
         private readonly TFrom m_parent;
         private readonly CesiumWriterAdaptorWriteCallback<TFrom, TValue> m_writeValueCallback;
@@ -93,6 +93,13 @@ namespace CesiumLanguageWriter.Advanced
         public ICesiumPropertyWriter IntervalWriter
         {
             get { return m_interval.Value; }
+        }
+
+        /// <inheritdoc />
+        public bool ForceInterval
+        {
+            get { return m_parent.ForceInterval; }
+            set { m_parent.ForceInterval = value; }
         }
 
         /// <inheritdoc />

--- a/DotNet/CesiumLanguageWriter/Advanced/ICesiumPropertyWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/ICesiumPropertyWriter.cs
@@ -32,5 +32,10 @@
         /// open the writer, instead of accessing this property directly.
         /// </summary>
         ICesiumPropertyWriter IntervalWriter { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance should always open an interval.
+        /// </summary>
+        bool ForceInterval { get; set; }
     }
 }

--- a/DotNet/CesiumLanguageWriter/Generated/AlignedAxisCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/AlignedAxisCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected AlignedAxisCesiumWriter(AlignedAxisCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/BillboardCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/BillboardCesiumWriter.cs
@@ -85,7 +85,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected BillboardCesiumWriter(BillboardCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/BooleanCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/BooleanCesiumWriter.cs
@@ -30,7 +30,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected BooleanCesiumWriter(BooleanCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -50,6 +50,8 @@ namespace CesiumLanguageWriter
         public void WriteBoolean(bool value)
         {
             const string PropertyName = BooleanPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(value);

--- a/DotNet/CesiumLanguageWriter/Generated/ClockCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ClockCesiumWriter.cs
@@ -43,7 +43,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected ClockCesiumWriter(ClockCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/ColorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ColorCesiumWriter.cs
@@ -44,7 +44,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected ColorCesiumWriter(ColorCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/ConicSensorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ConicSensorCesiumWriter.cs
@@ -133,7 +133,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected ConicSensorCesiumWriter(ConicSensorCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/CustomPatternSensorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/CustomPatternSensorCesiumWriter.cs
@@ -115,7 +115,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected CustomPatternSensorCesiumWriter(CustomPatternSensorCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/DirectionCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/DirectionCesiumWriter.cs
@@ -64,7 +64,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected DirectionCesiumWriter(DirectionCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/DirectionListCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/DirectionListCesiumWriter.cs
@@ -52,7 +52,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected DirectionListCesiumWriter(DirectionListCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/DoubleCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/DoubleCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected DoubleCesiumWriter(DoubleCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -59,6 +59,8 @@ namespace CesiumLanguageWriter
         public void WriteNumber(double value)
         {
             const string PropertyName = NumberPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(value);

--- a/DotNet/CesiumLanguageWriter/Generated/EllipseCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/EllipseCesiumWriter.cs
@@ -103,7 +103,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected EllipseCesiumWriter(EllipseCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/EllipsoidCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/EllipsoidCesiumWriter.cs
@@ -79,7 +79,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected EllipsoidCesiumWriter(EllipsoidCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/EllipsoidRadiiCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/EllipsoidRadiiCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected EllipsoidRadiiCesiumWriter(EllipsoidRadiiCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/EyeOffsetCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/EyeOffsetCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected EyeOffsetCesiumWriter(EyeOffsetCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/FanCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/FanCesiumWriter.cs
@@ -79,7 +79,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected FanCesiumWriter(FanCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/FontCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/FontCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected FontCesiumWriter(FontCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WriteFont(string font)
         {
             const string PropertyName = FontPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(font);

--- a/DotNet/CesiumLanguageWriter/Generated/GridMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/GridMaterialCesiumWriter.cs
@@ -55,7 +55,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected GridMaterialCesiumWriter(GridMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/HorizontalOriginCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/HorizontalOriginCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected HorizontalOriginCesiumWriter(HorizontalOriginCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WriteHorizontalOrigin(CesiumHorizontalOrigin value)
         {
             const string PropertyName = HorizontalOriginPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.HorizontalOriginToString(value));

--- a/DotNet/CesiumLanguageWriter/Generated/ImageMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ImageMaterialCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected ImageMaterialCesiumWriter(ImageMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/LabelCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/LabelCesiumWriter.cs
@@ -97,7 +97,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected LabelCesiumWriter(LabelCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/LabelStyleCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/LabelStyleCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected LabelStyleCesiumWriter(LabelStyleCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WriteLabelStyle(CesiumLabelStyle value)
         {
             const string PropertyName = LabelStylePropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.LabelStyleToString(value));

--- a/DotNet/CesiumLanguageWriter/Generated/LineCountCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/LineCountCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected LineCountCesiumWriter(LineCountCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/LineOffsetCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/LineOffsetCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected LineOffsetCesiumWriter(LineOffsetCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/LineThicknessCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/LineThicknessCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected LineThicknessCesiumWriter(LineThicknessCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/MaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/MaterialCesiumWriter.cs
@@ -49,7 +49,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected MaterialCesiumWriter(MaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/ModelCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/ModelCesiumWriter.cs
@@ -49,7 +49,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected ModelCesiumWriter(ModelCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/OrientationCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/OrientationCesiumWriter.cs
@@ -43,7 +43,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected OrientationCesiumWriter(OrientationCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PathCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PathCesiumWriter.cs
@@ -60,7 +60,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PathCesiumWriter(PathCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PixelOffsetCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PixelOffsetCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PixelOffsetCesiumWriter(PixelOffsetCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PointCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PointCesiumWriter.cs
@@ -55,7 +55,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PointCesiumWriter(PointCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PolygonCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PolygonCesiumWriter.cs
@@ -91,7 +91,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PolygonCesiumWriter(PolygonCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PolylineCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PolylineCesiumWriter.cs
@@ -54,7 +54,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PolylineCesiumWriter(PolylineCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PolylineGlowMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PolylineGlowMaterialCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PolylineGlowMaterialCesiumWriter(PolylineGlowMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PolylineMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PolylineMaterialCesiumWriter.cs
@@ -42,7 +42,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PolylineMaterialCesiumWriter(PolylineMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PolylineOutlineMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PolylineOutlineMaterialCesiumWriter.cs
@@ -43,7 +43,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PolylineOutlineMaterialCesiumWriter(PolylineOutlineMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PositionCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PositionCesiumWriter.cs
@@ -64,7 +64,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PositionCesiumWriter(PositionCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/PositionListCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PositionListCesiumWriter.cs
@@ -57,7 +57,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected PositionListCesiumWriter(PositionListCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/RectangularSensorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/RectangularSensorCesiumWriter.cs
@@ -121,7 +121,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected RectangularSensorCesiumWriter(RectangularSensorCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/RepeatCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/RepeatCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected RepeatCesiumWriter(RepeatCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/SensorVolumePortionToDisplayCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/SensorVolumePortionToDisplayCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected SensorVolumePortionToDisplayCesiumWriter(SensorVolumePortionToDisplayCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WritePortionToDisplay(CesiumSensorVolumePortionToDisplay value)
         {
             const string PropertyName = PortionToDisplayPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.SensorVolumePortionToDisplayToString(value));

--- a/DotNet/CesiumLanguageWriter/Generated/SolidColorMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/SolidColorMaterialCesiumWriter.cs
@@ -31,7 +31,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected SolidColorMaterialCesiumWriter(SolidColorMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/StringCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/StringCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected StringCesiumWriter(StringCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WriteString(string value)
         {
             const string PropertyName = StringPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(value);

--- a/DotNet/CesiumLanguageWriter/Generated/StripeMaterialCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/StripeMaterialCesiumWriter.cs
@@ -55,7 +55,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected StripeMaterialCesiumWriter(StripeMaterialCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/StripeOrientationCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/StripeOrientationCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected StripeOrientationCesiumWriter(StripeOrientationCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WriteStripeOrientation(CesiumStripeOrientation value)
         {
             const string PropertyName = StripeOrientationPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.StripeOrientationToString(value));

--- a/DotNet/CesiumLanguageWriter/Generated/UriCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/UriCesiumWriter.cs
@@ -38,7 +38,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected UriCesiumWriter(UriCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -69,6 +69,8 @@ namespace CesiumLanguageWriter
         public void WriteUri(Uri uri, CesiumResourceBehavior resourceBehavior)
         {
             const string PropertyName = UriPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.GetResourceUri(uri, resourceBehavior));
@@ -82,6 +84,8 @@ namespace CesiumLanguageWriter
         public void WriteUri(Uri uri, ICesiumUriResolver resolver)
         {
             const string PropertyName = UriPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(resolver.ResolveUri(uri));
@@ -104,6 +108,8 @@ namespace CesiumLanguageWriter
         public void WriteUri(Image image, CesiumImageFormat imageFormat)
         {
             const string PropertyName = UriPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.ImageToDataUri(image, imageFormat));

--- a/DotNet/CesiumLanguageWriter/Generated/VectorCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/VectorCesiumWriter.cs
@@ -55,7 +55,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected VectorCesiumWriter(VectorCesiumWriter existingInstance)
             : base(existingInstance)
         {

--- a/DotNet/CesiumLanguageWriter/Generated/VerticalOriginCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/VerticalOriginCesiumWriter.cs
@@ -37,7 +37,7 @@ namespace CesiumLanguageWriter
         /// <summary>
         /// Initializes a new instance as a copy of an existing instance.
         /// </summary>
-        /// <param name="existingInstance">The existing instance to copy.</param> 
+        /// <param name="existingInstance">The existing instance to copy.</param>
         protected VerticalOriginCesiumWriter(VerticalOriginCesiumWriter existingInstance)
             : base(existingInstance)
         {
@@ -58,6 +58,8 @@ namespace CesiumLanguageWriter
         public void WriteVerticalOrigin(CesiumVerticalOrigin value)
         {
             const string PropertyName = VerticalOriginPropertyName;
+            if (ForceInterval)
+                OpenIntervalIfNecessary();
             if (IsInterval)
                 Output.WritePropertyName(PropertyName);
             Output.WriteValue(CesiumFormattingHelper.VerticalOriginToString(value));

--- a/DotNet/CesiumLanguageWriterTests/CesiumLanguageWriterTests.csproj
+++ b/DotNet/CesiumLanguageWriterTests/CesiumLanguageWriterTests.csproj
@@ -41,21 +41,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\CesiumLanguageWriter\Attributes\CoverageExcludeAttribute.cs">
-      <Link>Attributes\CoverageExcludeAttribute.cs</Link>
-    </Compile>
-    <Compile Include="..\CesiumLanguageWriter\Attributes\CSToJavaExcludeAttribute.cs">
-      <Link>Attributes\CSToJavaExcludeAttribute.cs</Link>
-    </Compile>
-    <Compile Include="..\CesiumLanguageWriter\Attributes\CSToJavaExcludeBaseAttribute.cs">
-      <Link>Attributes\CSToJavaExcludeBaseAttribute.cs</Link>
-    </Compile>
-    <Compile Include="..\CesiumLanguageWriter\Attributes\CSToJavaImmutableValueType.cs">
-      <Link>Attributes\CSToJavaImmutableValueType.cs</Link>
-    </Compile>
-    <Compile Include="..\CesiumLanguageWriter\Attributes\CSToJavaRenameAttribute.cs">
-      <Link>Attributes\CSToJavaRenameAttribute.cs</Link>
-    </Compile>
     <Compile Include="Advanced\TestCesiumFormattingHelper.cs" />
     <Compile Include="Advanced\TestCesiumWritingHelper.cs" />
     <Compile Include="grisu\TestGrisu.cs" />

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/BooleanCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/BooleanCesiumWriter.java
@@ -71,6 +71,9 @@ public class BooleanCesiumWriter extends CesiumPropertyWriter<BooleanCesiumWrite
 	 */
 	public final void writeBoolean(boolean value) {
 		String PropertyName = BooleanPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/DoubleCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/DoubleCesiumWriter.java
@@ -93,6 +93,9 @@ public class DoubleCesiumWriter extends CesiumInterpolatablePropertyWriter<Doubl
 	 */
 	public final void writeNumber(double value) {
 		String PropertyName = NumberPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/FontCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/FontCesiumWriter.java
@@ -92,6 +92,9 @@ public class FontCesiumWriter extends CesiumPropertyWriter<FontCesiumWriter> {
 	 */
 	public final void writeFont(String font) {
 		String PropertyName = FontPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/HorizontalOriginCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/HorizontalOriginCesiumWriter.java
@@ -93,6 +93,9 @@ public class HorizontalOriginCesiumWriter extends CesiumPropertyWriter<Horizonta
 	 */
 	public final void writeHorizontalOrigin(CesiumHorizontalOrigin value) {
 		String PropertyName = HorizontalOriginPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/LabelStyleCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/LabelStyleCesiumWriter.java
@@ -93,6 +93,9 @@ public class LabelStyleCesiumWriter extends CesiumPropertyWriter<LabelStyleCesiu
 	 */
 	public final void writeLabelStyle(CesiumLabelStyle value) {
 		String PropertyName = LabelStylePropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/SensorVolumePortionToDisplayCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/SensorVolumePortionToDisplayCesiumWriter.java
@@ -93,6 +93,9 @@ public class SensorVolumePortionToDisplayCesiumWriter extends CesiumPropertyWrit
 	 */
 	public final void writePortionToDisplay(CesiumSensorVolumePortionToDisplay value) {
 		String PropertyName = PortionToDisplayPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/StringCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/StringCesiumWriter.java
@@ -92,6 +92,9 @@ public class StringCesiumWriter extends CesiumPropertyWriter<StringCesiumWriter>
 	 */
 	public final void writeString(String value) {
 		String PropertyName = StringPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/StripeOrientationCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/StripeOrientationCesiumWriter.java
@@ -93,6 +93,9 @@ public class StripeOrientationCesiumWriter extends CesiumPropertyWriter<StripeOr
 	 */
 	public final void writeStripeOrientation(CesiumStripeOrientation value) {
 		String PropertyName = StripeOrientationPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/UriCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/UriCesiumWriter.java
@@ -109,6 +109,9 @@ public class UriCesiumWriter extends CesiumPropertyWriter<UriCesiumWriter> {
 	 */
 	public final void writeUri(URI uri, CesiumResourceBehavior resourceBehavior) {
 		String PropertyName = UriPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}
@@ -127,6 +130,9 @@ public class UriCesiumWriter extends CesiumPropertyWriter<UriCesiumWriter> {
 	 */
 	public final void writeUri(URI uri, ICesiumUriResolver resolver) {
 		String PropertyName = UriPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}
@@ -157,6 +163,9 @@ public class UriCesiumWriter extends CesiumPropertyWriter<UriCesiumWriter> {
 	 */
 	public final void writeUri(RenderedImage image, CesiumImageFormat imageFormat) {
 		String PropertyName = UriPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/VerticalOriginCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/VerticalOriginCesiumWriter.java
@@ -93,6 +93,9 @@ public class VerticalOriginCesiumWriter extends CesiumPropertyWriter<VerticalOri
 	 */
 	public final void writeVerticalOrigin(CesiumVerticalOrigin value) {
 		String PropertyName = VerticalOriginPropertyName;
+		if (getForceInterval()) {
+			openIntervalIfNecessary();
+		}
 		if (getIsInterval()) {
 			getOutput().writePropertyName(PropertyName);
 		}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumInterpolatableWriterAdaptor.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumInterpolatableWriterAdaptor.java
@@ -129,6 +129,14 @@ public class CesiumInterpolatableWriterAdaptor<TFrom extends ICesiumPropertyWrit
 		return m_interval.getValue();
 	}
 
+	public final boolean getForceInterval() {
+		return m_parent.getForceInterval();
+	}
+
+	public final void setForceInterval(boolean value) {
+		m_parent.setForceInterval(value);
+	}
+
 	public final void open(CesiumOutputStream output) {
 		m_parent.open(output);
 	}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumPropertyWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumPropertyWriter.java
@@ -135,6 +135,24 @@ public abstract class CesiumPropertyWriter<TDerived extends CesiumPropertyWriter
 	}
 
 	/**
+	 *  Gets a value indicating whether this instance should always open an interval.
+	
+
+	 */
+	public final boolean getForceInterval() {
+		return backingField$ForceInterval;
+	}
+
+	/**
+	 *  Sets a value indicating whether this instance should always open an interval.
+	
+
+	 */
+	public final void setForceInterval(boolean value) {
+		backingField$ForceInterval = value;
+	}
+
+	/**
 	 *  
 	Copies this instance and returns the copy.
 	
@@ -254,4 +272,6 @@ public abstract class CesiumPropertyWriter<TDerived extends CesiumPropertyWriter
 		result.m_elementType = ElementType.INTERVAL;
 		return result;
 	}
+
+	private boolean backingField$ForceInterval;
 }

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumWriterAdaptor.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumWriterAdaptor.java
@@ -91,6 +91,14 @@ public class CesiumWriterAdaptor<TFrom extends ICesiumPropertyWriter, TValue> im
 		return m_interval.getValue();
 	}
 
+	public final boolean getForceInterval() {
+		return m_parent.getForceInterval();
+	}
+
+	public final void setForceInterval(boolean value) {
+		m_parent.setForceInterval(value);
+	}
+
 	public final void open(CesiumOutputStream output) {
 		m_parent.open(output);
 	}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/ICesiumPropertyWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/ICesiumPropertyWriter.java
@@ -53,4 +53,18 @@ public interface ICesiumPropertyWriter extends ICesiumElementWriter {
 
 	 */
 	ICesiumPropertyWriter getIntervalWriter();
+
+	/**
+	 *  Gets a value indicating whether this instance should always open an interval.
+	
+
+	 */
+	boolean getForceInterval();
+
+	/**
+	 *  Sets a value indicating whether this instance should always open an interval.
+	
+
+	 */
+	void setForceInterval(boolean value);
 }


### PR DESCRIPTION
This indicates that values should be written out as an interval, even if not strictly required.  This will be useful for writing custom CZML properties, when a future version of Cesium automatically detects and loads those properties.
