### PR TITLE
Fix CesiumVerticalOrigin.Baseline

### DIFF
--- a/DotNet/CesiumLanguageWriter/Advanced/CesiumFormattingHelper.cs
+++ b/DotNet/CesiumLanguageWriter/Advanced/CesiumFormattingHelper.cs
@@ -232,6 +232,8 @@ namespace CesiumLanguageWriter.Advanced
                     return "CENTER";
                 case CesiumVerticalOrigin.Top:
                     return "TOP";
+                case CesiumVerticalOrigin.Baseline:
+                    return "BASELINE";
                 default:
                     throw new ArgumentException(CesiumLocalization.UnknownEnumerationValue, "value");
             }

--- a/DotNet/CesiumLanguageWriterTests/CesiumLanguageWriterTests.csproj
+++ b/DotNet/CesiumLanguageWriterTests/CesiumLanguageWriterTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="TestBoundingRectangle.cs" />
     <Compile Include="TestCartesian3.cs" />
     <Compile Include="TestCartographic.cs" />
+    <Compile Include="TestCesiumFormattingHelper.cs" />
     <Compile Include="TestCesiumInterpolatablePropertyWriter.cs" />
     <Compile Include="TestCustomPropertiesCesiumWriter.cs" />
     <Compile Include="TestDoubleCesiumWriter.cs" />

--- a/DotNet/CesiumLanguageWriterTests/TestCesiumFormattingHelper.cs
+++ b/DotNet/CesiumLanguageWriterTests/TestCesiumFormattingHelper.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using CesiumLanguageWriter;
+using CesiumLanguageWriter.Advanced;
+using NUnit.Framework;
+
+namespace CesiumLanguageWriterTests
+{
+    [TestFixture]
+    public class TestCesiumFormattingHelper
+    {
+        [Test]
+        [TestCaseSource("ClockRangeValues")]
+        public void TestClockRangeToString(ClockRange value)
+        {
+            string s = CesiumFormattingHelper.ClockRangeToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<ClockRange> ClockRangeValues
+        {
+            get { return (ClockRange[])Enum.GetValues(typeof(ClockRange)); }
+        }
+
+        [Test]
+        [TestCaseSource("ClockStepValues")]
+        public void TestClockStepToString(ClockStep value)
+        {
+            string s = CesiumFormattingHelper.ClockStepToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<ClockStep> ClockStepValues
+        {
+            get { return (ClockStep[])Enum.GetValues(typeof(ClockStep)); }
+        }
+
+        [Test]
+        [TestCaseSource("ColorBlendModeValues")]
+        public void TestColorBlendModeToString(CesiumColorBlendMode value)
+        {
+            string s = CesiumFormattingHelper.ColorBlendModeToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumColorBlendMode> ColorBlendModeValues
+        {
+            get { return (CesiumColorBlendMode[])Enum.GetValues(typeof(CesiumColorBlendMode)); }
+        }
+
+        [Test]
+        [TestCaseSource("CornerTypeValues")]
+        public void TestCornerTypeToString(CesiumCornerType value)
+        {
+            string s = CesiumFormattingHelper.CornerTypeToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumCornerType> CornerTypeValues
+        {
+            get { return (CesiumCornerType[])Enum.GetValues(typeof(CesiumCornerType)); }
+        }
+
+        [Test]
+        [TestCaseSource("ExtrapolationTypeValues")]
+        public void TestExtrapolationTypeToString(CesiumExtrapolationType value)
+        {
+            string s = CesiumFormattingHelper.ExtrapolationTypeToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumExtrapolationType> ExtrapolationTypeValues
+        {
+            get { return (CesiumExtrapolationType[])Enum.GetValues(typeof(CesiumExtrapolationType)); }
+        }
+
+        [Test]
+        [TestCaseSource("HeightReferenceValues")]
+        public void TestHeightReferenceToString(CesiumHeightReference value)
+        {
+            string s = CesiumFormattingHelper.HeightReferenceToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumHeightReference> HeightReferenceValues
+        {
+            get { return (CesiumHeightReference[])Enum.GetValues(typeof(CesiumHeightReference)); }
+        }
+
+        [Test]
+        [TestCaseSource("HorizontalOriginValues")]
+        public void TestHorizontalOriginToString(CesiumHorizontalOrigin value)
+        {
+            string s = CesiumFormattingHelper.HorizontalOriginToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumHorizontalOrigin> HorizontalOriginValues
+        {
+            get { return (CesiumHorizontalOrigin[])Enum.GetValues(typeof(CesiumHorizontalOrigin)); }
+        }
+
+        [Test]
+        [TestCaseSource("InterpolationAlgorithmValues")]
+        public void TestInterpolationAlgorithmToString(CesiumInterpolationAlgorithm value)
+        {
+            string s = CesiumFormattingHelper.InterpolationAlgorithmToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumInterpolationAlgorithm> InterpolationAlgorithmValues
+        {
+            get { return (CesiumInterpolationAlgorithm[])Enum.GetValues(typeof(CesiumInterpolationAlgorithm)); }
+        }
+
+        [Test]
+        [TestCaseSource("LabelStyleValues")]
+        public void TestLabelStyleToString(CesiumLabelStyle value)
+        {
+            string s = CesiumFormattingHelper.LabelStyleToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumLabelStyle> LabelStyleValues
+        {
+            get { return (CesiumLabelStyle[])Enum.GetValues(typeof(CesiumLabelStyle)); }
+        }
+
+        [Test]
+        [TestCaseSource("SensorVolumePortionToDisplayValues")]
+        public void TestSensorVolumePortionToDisplayToString(CesiumSensorVolumePortionToDisplay value)
+        {
+            string s = CesiumFormattingHelper.SensorVolumePortionToDisplayToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumSensorVolumePortionToDisplay> SensorVolumePortionToDisplayValues
+        {
+            get { return (CesiumSensorVolumePortionToDisplay[])Enum.GetValues(typeof(CesiumSensorVolumePortionToDisplay)); }
+        }
+
+        [Test]
+        [TestCaseSource("ShadowModeValues")]
+        public void TestShadowModeToString(CesiumShadowMode value)
+        {
+            string s = CesiumFormattingHelper.ShadowModeToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumShadowMode> ShadowModeValues
+        {
+            get { return (CesiumShadowMode[])Enum.GetValues(typeof(CesiumShadowMode)); }
+        }
+
+        [Test]
+        [TestCaseSource("StripeOrientationValues")]
+        public void TestStripeOrientationToString(CesiumStripeOrientation value)
+        {
+            string s = CesiumFormattingHelper.StripeOrientationToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumStripeOrientation> StripeOrientationValues
+        {
+            get { return (CesiumStripeOrientation[])Enum.GetValues(typeof(CesiumStripeOrientation)); }
+        }
+
+        [Test]
+        [TestCaseSource("VerticalOriginValues")]
+        public void TestVerticalOriginToString(CesiumVerticalOrigin value)
+        {
+            string s = CesiumFormattingHelper.VerticalOriginToString(value);
+            Assert.IsNotNull(s);
+        }
+
+        public IEnumerable<CesiumVerticalOrigin> VerticalOriginValues
+        {
+            get { return (CesiumVerticalOrigin[])Enum.GetValues(typeof(CesiumVerticalOrigin)); }
+        }
+    }
+}

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/CesiumOutputStream.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/CesiumOutputStream.java
@@ -126,7 +126,7 @@ public class CesiumOutputStream {
     
     
 
-    * @param propertyName 
+    * @param propertyName The name of the property.
     */
     public final void writePropertyName(String propertyName) {
         m_nextValueOnNewLine = true;

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/NearFarScalar.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/NearFarScalar.java
@@ -48,8 +48,7 @@ public final class NearFarScalar implements IEquatable<NearFarScalar>, Immutable
     }
 
     /**
-    *  
-    The lower bound of the camera distance range.
+    *  Gets the lower bound of the camera distance range.
     
 
     */
@@ -58,8 +57,7 @@ public final class NearFarScalar implements IEquatable<NearFarScalar>, Immutable
     }
 
     /**
-    *  
-    The value to use at the lower bound of the camera distance range.
+    *  Gets the value to use at the lower bound of the camera distance range.
     
 
     */
@@ -68,8 +66,7 @@ public final class NearFarScalar implements IEquatable<NearFarScalar>, Immutable
     }
 
     /**
-    *  
-    The upper bound of the camera distance range.
+    *  Gets the upper bound of the camera distance range.
     
 
     */
@@ -78,8 +75,7 @@ public final class NearFarScalar implements IEquatable<NearFarScalar>, Immutable
     }
 
     /**
-    *  
-    The value to use at the upper bound of the camera distance range.
+    *  Gets the value to use at the upper bound of the camera distance range.
     
 
     */

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CachingCesiumUriResolver.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CachingCesiumUriResolver.java
@@ -80,7 +80,7 @@ public class CachingCesiumUriResolver implements ICesiumUriResolver {
 
     /**
     *  
-    Add a URI to the cache for future calls to ResolveUri.
+    Add a URI to the cache for future calls to {@link #resolveUri}.
     
     
     

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumFormattingHelper.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/advanced/CesiumFormattingHelper.java
@@ -309,6 +309,9 @@ public final class CesiumFormattingHelper {
         case TOP: {
             return "TOP";
         }
+        case BASELINE: {
+            return "BASELINE";
+        }
         default: {
             throw new ArgumentException(CesiumLocalization.getUnknownEnumerationValue(), "value");
         }

--- a/Java/CesiumLanguageWriterTests/src/agi/foundation/compatibility/EnumHelper.java
+++ b/Java/CesiumLanguageWriterTests/src/agi/foundation/compatibility/EnumHelper.java
@@ -1,0 +1,45 @@
+package agi.foundation.compatibility;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Helper methods for Enums.
+ */
+public final class EnumHelper {
+    private EnumHelper() {}
+
+    /**
+     * Retrieves an array of the values of the constants in a specified enumeration.
+     *
+     * @param enumType
+     *            An enumeration type.
+     * @return An array that contains the values of the constants in enumType.
+     */
+    public static <T> T[] getValues(Class<T> enumType) {
+        T[] values;
+
+        if (enumType.isEnum()) {
+            values = enumType.getEnumConstants();
+        } else {
+            Method method;
+            try {
+                method = enumType.getMethod("values", new Class<?>[0]);
+                method.setAccessible(true);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeNoSuchMethodException(e);
+            }
+            try {
+                @SuppressWarnings("unchecked")
+                T[] temp = (T[]) method.invoke(null);
+                values = temp;
+            } catch (IllegalAccessException e) {
+                throw new RuntimeIllegalAccessException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeInvocationTargetException(e);
+            }
+        }
+
+        return values;
+    }
+}

--- a/Java/CesiumLanguageWriterTests/src/agi/foundation/compatibility/RuntimeNoSuchMethodException.java
+++ b/Java/CesiumLanguageWriterTests/src/agi/foundation/compatibility/RuntimeNoSuchMethodException.java
@@ -1,0 +1,20 @@
+package agi.foundation.compatibility;
+
+/**
+ * {@link RuntimeException} wrapper around {@link NoSuchMethodException}.
+ */
+public class RuntimeNoSuchMethodException extends WrappedRuntimeException {
+    private static final long serialVersionUID = -7060058165456497629L;
+
+    public RuntimeNoSuchMethodException(NoSuchMethodException e) {
+        super(e);
+    }
+
+    public RuntimeNoSuchMethodException() {
+        this(new NoSuchMethodException());
+    }
+
+    public RuntimeNoSuchMethodException(String s) {
+        this(new NoSuchMethodException(s));
+    }
+}

--- a/Java/CesiumLanguageWriterTests/translatedSrc/cesiumlanguagewritertests/TestCesiumFormattingHelper.java
+++ b/Java/CesiumLanguageWriterTests/translatedSrc/cesiumlanguagewritertests/TestCesiumFormattingHelper.java
@@ -1,0 +1,232 @@
+package cesiumlanguagewritertests;
+
+
+import agi.foundation.compatibility.*;
+import agi.foundation.compatibility.ArrayHelper;
+import agi.foundation.compatibility.EnumHelper;
+import agi.foundation.compatibility.TestContextRule;
+import cesiumlanguagewriter.*;
+import cesiumlanguagewriter.advanced.*;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.runners.MethodSorters;
+import org.junit.Test;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestCesiumFormattingHelper {
+    public final void testClockRangeToString(ClockRange value) {
+        String s = CesiumFormattingHelper.clockRangeToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testClockRangeToString$TestCase1() {
+        for (final ClockRange value : getClockRangeValues()) {
+            testClockRangeToString(value);
+        }
+    }
+
+    public final Iterable<ClockRange> getClockRangeValues() {
+        return ArrayHelper.arrayAsList((ClockRange[]) EnumHelper.getValues(ClockRange.class));
+    }
+
+    public final void testClockStepToString(ClockStep value) {
+        String s = CesiumFormattingHelper.clockStepToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testClockStepToString$TestCase1() {
+        for (final ClockStep value : getClockStepValues()) {
+            testClockStepToString(value);
+        }
+    }
+
+    public final Iterable<ClockStep> getClockStepValues() {
+        return ArrayHelper.arrayAsList((ClockStep[]) EnumHelper.getValues(ClockStep.class));
+    }
+
+    public final void testColorBlendModeToString(CesiumColorBlendMode value) {
+        String s = CesiumFormattingHelper.colorBlendModeToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testColorBlendModeToString$TestCase1() {
+        for (final CesiumColorBlendMode value : getColorBlendModeValues()) {
+            testColorBlendModeToString(value);
+        }
+    }
+
+    public final Iterable<CesiumColorBlendMode> getColorBlendModeValues() {
+        return ArrayHelper.arrayAsList((CesiumColorBlendMode[]) EnumHelper.getValues(CesiumColorBlendMode.class));
+    }
+
+    public final void testCornerTypeToString(CesiumCornerType value) {
+        String s = CesiumFormattingHelper.cornerTypeToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testCornerTypeToString$TestCase1() {
+        for (final CesiumCornerType value : getCornerTypeValues()) {
+            testCornerTypeToString(value);
+        }
+    }
+
+    public final Iterable<CesiumCornerType> getCornerTypeValues() {
+        return ArrayHelper.arrayAsList((CesiumCornerType[]) EnumHelper.getValues(CesiumCornerType.class));
+    }
+
+    public final void testExtrapolationTypeToString(CesiumExtrapolationType value) {
+        String s = CesiumFormattingHelper.extrapolationTypeToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testExtrapolationTypeToString$TestCase1() {
+        for (final CesiumExtrapolationType value : getExtrapolationTypeValues()) {
+            testExtrapolationTypeToString(value);
+        }
+    }
+
+    public final Iterable<CesiumExtrapolationType> getExtrapolationTypeValues() {
+        return ArrayHelper.arrayAsList((CesiumExtrapolationType[]) EnumHelper.getValues(CesiumExtrapolationType.class));
+    }
+
+    public final void testHeightReferenceToString(CesiumHeightReference value) {
+        String s = CesiumFormattingHelper.heightReferenceToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testHeightReferenceToString$TestCase1() {
+        for (final CesiumHeightReference value : getHeightReferenceValues()) {
+            testHeightReferenceToString(value);
+        }
+    }
+
+    public final Iterable<CesiumHeightReference> getHeightReferenceValues() {
+        return ArrayHelper.arrayAsList((CesiumHeightReference[]) EnumHelper.getValues(CesiumHeightReference.class));
+    }
+
+    public final void testHorizontalOriginToString(CesiumHorizontalOrigin value) {
+        String s = CesiumFormattingHelper.horizontalOriginToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testHorizontalOriginToString$TestCase1() {
+        for (final CesiumHorizontalOrigin value : getHorizontalOriginValues()) {
+            testHorizontalOriginToString(value);
+        }
+    }
+
+    public final Iterable<CesiumHorizontalOrigin> getHorizontalOriginValues() {
+        return ArrayHelper.arrayAsList((CesiumHorizontalOrigin[]) EnumHelper.getValues(CesiumHorizontalOrigin.class));
+    }
+
+    public final void testInterpolationAlgorithmToString(CesiumInterpolationAlgorithm value) {
+        String s = CesiumFormattingHelper.interpolationAlgorithmToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testInterpolationAlgorithmToString$TestCase1() {
+        for (final CesiumInterpolationAlgorithm value : getInterpolationAlgorithmValues()) {
+            testInterpolationAlgorithmToString(value);
+        }
+    }
+
+    public final Iterable<CesiumInterpolationAlgorithm> getInterpolationAlgorithmValues() {
+        return ArrayHelper.arrayAsList((CesiumInterpolationAlgorithm[]) EnumHelper.getValues(CesiumInterpolationAlgorithm.class));
+    }
+
+    public final void testLabelStyleToString(CesiumLabelStyle value) {
+        String s = CesiumFormattingHelper.labelStyleToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testLabelStyleToString$TestCase1() {
+        for (final CesiumLabelStyle value : getLabelStyleValues()) {
+            testLabelStyleToString(value);
+        }
+    }
+
+    public final Iterable<CesiumLabelStyle> getLabelStyleValues() {
+        return ArrayHelper.arrayAsList((CesiumLabelStyle[]) EnumHelper.getValues(CesiumLabelStyle.class));
+    }
+
+    public final void testSensorVolumePortionToDisplayToString(CesiumSensorVolumePortionToDisplay value) {
+        String s = CesiumFormattingHelper.sensorVolumePortionToDisplayToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testSensorVolumePortionToDisplayToString$TestCase1() {
+        for (final CesiumSensorVolumePortionToDisplay value : getSensorVolumePortionToDisplayValues()) {
+            testSensorVolumePortionToDisplayToString(value);
+        }
+    }
+
+    public final Iterable<CesiumSensorVolumePortionToDisplay> getSensorVolumePortionToDisplayValues() {
+        return ArrayHelper.arrayAsList((CesiumSensorVolumePortionToDisplay[]) EnumHelper.getValues(CesiumSensorVolumePortionToDisplay.class));
+    }
+
+    public final void testShadowModeToString(CesiumShadowMode value) {
+        String s = CesiumFormattingHelper.shadowModeToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testShadowModeToString$TestCase1() {
+        for (final CesiumShadowMode value : getShadowModeValues()) {
+            testShadowModeToString(value);
+        }
+    }
+
+    public final Iterable<CesiumShadowMode> getShadowModeValues() {
+        return ArrayHelper.arrayAsList((CesiumShadowMode[]) EnumHelper.getValues(CesiumShadowMode.class));
+    }
+
+    public final void testStripeOrientationToString(CesiumStripeOrientation value) {
+        String s = CesiumFormattingHelper.stripeOrientationToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testStripeOrientationToString$TestCase1() {
+        for (final CesiumStripeOrientation value : getStripeOrientationValues()) {
+            testStripeOrientationToString(value);
+        }
+    }
+
+    public final Iterable<CesiumStripeOrientation> getStripeOrientationValues() {
+        return ArrayHelper.arrayAsList((CesiumStripeOrientation[]) EnumHelper.getValues(CesiumStripeOrientation.class));
+    }
+
+    public final void testVerticalOriginToString(CesiumVerticalOrigin value) {
+        String s = CesiumFormattingHelper.verticalOriginToString(value);
+        Assert.assertNotNull(s);
+    }
+
+    @Test
+    public final void testVerticalOriginToString$TestCase1() {
+        for (final CesiumVerticalOrigin value : getVerticalOriginValues()) {
+            testVerticalOriginToString(value);
+        }
+    }
+
+    public final Iterable<CesiumVerticalOrigin> getVerticalOriginValues() {
+        return ArrayHelper.arrayAsList((CesiumVerticalOrigin[]) EnumHelper.getValues(CesiumVerticalOrigin.class));
+    }
+
+    private TestContextRule rule$testContext = new TestContextRule();
+
+    @Rule
+    public TestContextRule getRule$testContext() {
+        return rule$testContext;
+    }
+}


### PR DESCRIPTION
When Baseline was added, the conversion to string was not added.  Also add a test that makes sure converting all enum values to string works.