### PR TITLE
Add velocityReference orientation support.

### DIFF
--- a/DotNet/CesiumLanguageWriter/Generated/OrientationCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/OrientationCesiumWriter.cs
@@ -22,8 +22,14 @@ namespace CesiumLanguageWriter
         /// </summary>
         public const string ReferencePropertyName = "reference";
 
+        /// <summary>
+        /// The name of the <c>velocityReference</c> property.
+        /// </summary>
+        public const string VelocityReferencePropertyName = "velocityReference";
+
         private readonly Lazy<ICesiumInterpolatableValuePropertyWriter<UnitQuaternion>> m_asUnitQuaternion;
         private readonly Lazy<ICesiumValuePropertyWriter<Reference>> m_asReference;
+        private readonly Lazy<ICesiumValuePropertyWriter<Reference>> m_asVelocityReference;
 
         /// <summary>
         /// Initializes a new instance.
@@ -33,6 +39,7 @@ namespace CesiumLanguageWriter
         {
             m_asUnitQuaternion = new Lazy<ICesiumInterpolatableValuePropertyWriter<UnitQuaternion>>(CreateUnitQuaternionAdaptor, false);
             m_asReference = new Lazy<ICesiumValuePropertyWriter<Reference>>(CreateReferenceAdaptor, false);
+            m_asVelocityReference = new Lazy<ICesiumValuePropertyWriter<Reference>>(CreateVelocityReferenceAdaptor, false);
         }
 
         /// <summary>
@@ -44,6 +51,7 @@ namespace CesiumLanguageWriter
         {
             m_asUnitQuaternion = new Lazy<ICesiumInterpolatableValuePropertyWriter<UnitQuaternion>>(CreateUnitQuaternionAdaptor, false);
             m_asReference = new Lazy<ICesiumValuePropertyWriter<Reference>>(CreateReferenceAdaptor, false);
+            m_asVelocityReference = new Lazy<ICesiumValuePropertyWriter<Reference>>(CreateVelocityReferenceAdaptor, false);
         }
 
         /// <inheritdoc />
@@ -139,6 +147,56 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
+        /// Writes the value expressed as a <c>velocityReference</c>, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a <c>position</c> property.
+        /// </summary>
+        /// <param name="value">The reference.</param>
+        public void WriteVelocityReference(Reference value)
+        {
+            const string PropertyName = VelocityReferencePropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteReference(Output, value);
+        }
+
+        /// <summary>
+        /// Writes the value expressed as a <c>velocityReference</c>, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a <c>position</c> property.
+        /// </summary>
+        /// <param name="value">The earliest date of the interval.</param>
+        public void WriteVelocityReference(string value)
+        {
+            const string PropertyName = VelocityReferencePropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteReference(Output, value);
+        }
+
+        /// <summary>
+        /// Writes the value expressed as a <c>velocityReference</c>, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a <c>position</c> property.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyName">The property on the referenced object.</param>
+        public void WriteVelocityReference(string identifier, string propertyName)
+        {
+            const string PropertyName = VelocityReferencePropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteReference(Output, identifier, propertyName);
+        }
+
+        /// <summary>
+        /// Writes the value expressed as a <c>velocityReference</c>, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a <c>position</c> property.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
+        public void WriteVelocityReference(string identifier, string[] propertyNames)
+        {
+            const string PropertyName = VelocityReferencePropertyName;
+            OpenIntervalIfNecessary();
+            Output.WritePropertyName(PropertyName);
+            CesiumWritingHelper.WriteReference(Output, identifier, propertyNames);
+        }
+
+        /// <summary>
         /// Returns a wrapper for this instance that implements <see cref="ICesiumInterpolatableValuePropertyWriter{T}" /> to write a value in <c>UnitQuaternion</c> format.  Because the returned instance is a wrapper for this instance, you may call <see cref="ICesiumElementWriter.Close" /> on either this instance or the wrapper, but you must not call it on both.
         /// </summary>
         /// <returns>The wrapper.</returns>
@@ -164,6 +222,20 @@ namespace CesiumLanguageWriter
         private ICesiumValuePropertyWriter<Reference> CreateReferenceAdaptor()
         {
             return new CesiumWriterAdaptor<OrientationCesiumWriter, Reference>(this, (me, value) => me.WriteReference(value));
+        }
+
+        /// <summary>
+        /// Returns a wrapper for this instance that implements <see cref="ICesiumValuePropertyWriter{T}" /> to write a value in <c>VelocityReference</c> format.  Because the returned instance is a wrapper for this instance, you may call <see cref="ICesiumElementWriter.Close" /> on either this instance or the wrapper, but you must not call it on both.
+        /// </summary>
+        /// <returns>The wrapper.</returns>
+        public ICesiumValuePropertyWriter<Reference> AsVelocityReference()
+        {
+            return m_asVelocityReference.Value;
+        }
+
+        private ICesiumValuePropertyWriter<Reference> CreateVelocityReferenceAdaptor()
+        {
+            return new CesiumWriterAdaptor<OrientationCesiumWriter, Reference>(this, (me, value) => me.WriteVelocityReference(value));
         }
 
     }

--- a/DotNet/CesiumLanguageWriter/Generated/PacketCesiumWriter.cs
+++ b/DotNet/CesiumLanguageWriter/Generated/PacketCesiumWriter.cs
@@ -740,6 +740,56 @@ namespace CesiumLanguageWriter
         }
 
         /// <summary>
+        /// Writes a value for the <c>orientation</c> property as a <c>velocityReference</c> value.  The <c>orientation</c> property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+        /// </summary>
+        /// <param name="value">The reference.</param>
+        public void WriteOrientationPropertyVelocityReference(Reference value)
+        {
+            using (var writer = OpenOrientationProperty())
+            {
+                writer.WriteVelocityReference(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <c>orientation</c> property as a <c>velocityReference</c> value.  The <c>orientation</c> property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+        /// </summary>
+        /// <param name="value">The earliest date of the interval.</param>
+        public void WriteOrientationPropertyVelocityReference(string value)
+        {
+            using (var writer = OpenOrientationProperty())
+            {
+                writer.WriteVelocityReference(value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <c>orientation</c> property as a <c>velocityReference</c> value.  The <c>orientation</c> property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyName">The property on the referenced object.</param>
+        public void WriteOrientationPropertyVelocityReference(string identifier, string propertyName)
+        {
+            using (var writer = OpenOrientationProperty())
+            {
+                writer.WriteVelocityReference(identifier, propertyName);
+            }
+        }
+
+        /// <summary>
+        /// Writes a value for the <c>orientation</c> property as a <c>velocityReference</c> value.  The <c>orientation</c> property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+        /// </summary>
+        /// <param name="identifier">The identifier of the object which contains the referenced property.</param>
+        /// <param name="propertyNames">The hierarchy of properties to be indexed on the referenced object.</param>
+        public void WriteOrientationPropertyVelocityReference(string identifier, string[] propertyNames)
+        {
+            using (var writer = OpenOrientationProperty())
+            {
+                writer.WriteVelocityReference(identifier, propertyNames);
+            }
+        }
+
+        /// <summary>
         /// Gets the writer for the <c>viewFrom</c> property.  The returned instance must be opened by calling the <see cref="CesiumElementWriter.Open"/> method before it can be used for writing.  The <c>viewFrom</c> property defines a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the object's position.
         /// </summary>
         public ViewFromCesiumWriter ViewFromWriter

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/OrientationCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/OrientationCesiumWriter.java
@@ -31,8 +31,16 @@ public class OrientationCesiumWriter extends CesiumInterpolatablePropertyWriter<
 
     */
     public static final String ReferencePropertyName = "reference";
+    /**
+    *  
+    The name of the {@code velocityReference} property.
+    
+
+    */
+    public static final String VelocityReferencePropertyName = "velocityReference";
     private Lazy<ICesiumInterpolatableValuePropertyWriter<UnitQuaternion>> m_asUnitQuaternion;
     private Lazy<ICesiumValuePropertyWriter<Reference>> m_asReference;
+    private Lazy<ICesiumValuePropertyWriter<Reference>> m_asVelocityReference;
 
     /**
     *  
@@ -52,6 +60,12 @@ public class OrientationCesiumWriter extends CesiumInterpolatablePropertyWriter<
                 "createReferenceAdaptor", new Class[] {}) {
             public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference> invoke() {
                 return createReferenceAdaptor();
+            }
+        }, false);
+        m_asVelocityReference = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference>>(new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference>>(this,
+                "createVelocityReferenceAdaptor", new Class[] {}) {
+            public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference> invoke() {
+                return createVelocityReferenceAdaptor();
             }
         }, false);
     }
@@ -76,6 +90,12 @@ public class OrientationCesiumWriter extends CesiumInterpolatablePropertyWriter<
                 "createReferenceAdaptor", new Class[] {}) {
             public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference> invoke() {
                 return createReferenceAdaptor();
+            }
+        }, false);
+        m_asVelocityReference = new Lazy<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference>>(new Func1<cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference>>(this,
+                "createVelocityReferenceAdaptor", new Class[] {}) {
+            public cesiumlanguagewriter.advanced.ICesiumValuePropertyWriter<Reference> invoke() {
+                return createVelocityReferenceAdaptor();
             }
         }, false);
     }
@@ -200,6 +220,70 @@ public class OrientationCesiumWriter extends CesiumInterpolatablePropertyWriter<
 
     /**
     *  
+    Writes the value expressed as a {@code velocityReference}, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a {@code position} property.
+    
+    
+
+    * @param value The reference.
+    */
+    public final void writeVelocityReference(Reference value) {
+        final String PropertyName = VelocityReferencePropertyName;
+        openIntervalIfNecessary();
+        getOutput().writePropertyName(PropertyName);
+        CesiumWritingHelper.writeReference(getOutput(), value);
+    }
+
+    /**
+    *  
+    Writes the value expressed as a {@code velocityReference}, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a {@code position} property.
+    
+    
+
+    * @param value The earliest date of the interval.
+    */
+    public final void writeVelocityReference(String value) {
+        final String PropertyName = VelocityReferencePropertyName;
+        openIntervalIfNecessary();
+        getOutput().writePropertyName(PropertyName);
+        CesiumWritingHelper.writeReference(getOutput(), value);
+    }
+
+    /**
+    *  
+    Writes the value expressed as a {@code velocityReference}, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a {@code position} property.
+    
+    
+    
+
+    * @param identifier The identifier of the object which contains the referenced property.
+    * @param propertyName The property on the referenced object.
+    */
+    public final void writeVelocityReference(String identifier, String propertyName) {
+        final String PropertyName = VelocityReferencePropertyName;
+        openIntervalIfNecessary();
+        getOutput().writePropertyName(PropertyName);
+        CesiumWritingHelper.writeReference(getOutput(), identifier, propertyName);
+    }
+
+    /**
+    *  
+    Writes the value expressed as a {@code velocityReference}, which is the orientation specified as the normalized velocity vector of a position property. The reference must be to a {@code position} property.
+    
+    
+    
+
+    * @param identifier The identifier of the object which contains the referenced property.
+    * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
+    */
+    public final void writeVelocityReference(String identifier, String[] propertyNames) {
+        final String PropertyName = VelocityReferencePropertyName;
+        openIntervalIfNecessary();
+        getOutput().writePropertyName(PropertyName);
+        CesiumWritingHelper.writeReference(getOutput(), identifier, propertyNames);
+    }
+
+    /**
+    *  
     Returns a wrapper for this instance that implements {@link ICesiumInterpolatableValuePropertyWriter} to write a value in {@code UnitQuaternion} format.  Because the returned instance is a wrapper for this instance, you may call {@link ICesiumElementWriter#close} on either this instance or the wrapper, but you must not call it on both.
     
     
@@ -240,6 +324,27 @@ public class OrientationCesiumWriter extends CesiumInterpolatablePropertyWriter<
                 new CesiumWriterAdaptorWriteCallback<cesiumlanguagewriter.OrientationCesiumWriter, cesiumlanguagewriter.Reference>() {
                     public void invoke(OrientationCesiumWriter me, Reference value) {
                         me.writeReference(value);
+                    }
+                });
+    }
+
+    /**
+    *  
+    Returns a wrapper for this instance that implements {@link ICesiumValuePropertyWriter} to write a value in {@code VelocityReference} format.  Because the returned instance is a wrapper for this instance, you may call {@link ICesiumElementWriter#close} on either this instance or the wrapper, but you must not call it on both.
+    
+    
+
+    * @return The wrapper.
+    */
+    public final ICesiumValuePropertyWriter<Reference> asVelocityReference() {
+        return m_asVelocityReference.getValue();
+    }
+
+    private final ICesiumValuePropertyWriter<Reference> createVelocityReferenceAdaptor() {
+        return new CesiumWriterAdaptor<cesiumlanguagewriter.OrientationCesiumWriter, cesiumlanguagewriter.Reference>(this,
+                new CesiumWriterAdaptorWriteCallback<cesiumlanguagewriter.OrientationCesiumWriter, cesiumlanguagewriter.Reference>() {
+                    public void invoke(OrientationCesiumWriter me, Reference value) {
+                        me.writeVelocityReference(value);
                     }
                 });
     }

--- a/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PacketCesiumWriter.java
+++ b/Java/CesiumLanguageWriter/translatedSrc/cesiumlanguagewriter/PacketCesiumWriter.java
@@ -1199,6 +1199,86 @@ public class PacketCesiumWriter extends CesiumElementWriter {
     }
 
     /**
+    *  
+    Writes a value for the {@code orientation} property as a {@code velocityReference} value.  The {@code orientation} property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+    
+    
+
+    * @param value The reference.
+    */
+    public final void writeOrientationPropertyVelocityReference(Reference value) {
+        {
+            cesiumlanguagewriter.OrientationCesiumWriter writer = openOrientationProperty();
+            try {
+                writer.writeVelocityReference(value);
+            } finally {
+                DisposeHelper.dispose(writer);
+            }
+        }
+    }
+
+    /**
+    *  
+    Writes a value for the {@code orientation} property as a {@code velocityReference} value.  The {@code orientation} property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+    
+    
+
+    * @param value The earliest date of the interval.
+    */
+    public final void writeOrientationPropertyVelocityReference(String value) {
+        {
+            cesiumlanguagewriter.OrientationCesiumWriter writer = openOrientationProperty();
+            try {
+                writer.writeVelocityReference(value);
+            } finally {
+                DisposeHelper.dispose(writer);
+            }
+        }
+    }
+
+    /**
+    *  
+    Writes a value for the {@code orientation} property as a {@code velocityReference} value.  The {@code orientation} property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+    
+    
+    
+
+    * @param identifier The identifier of the object which contains the referenced property.
+    * @param propertyName The property on the referenced object.
+    */
+    public final void writeOrientationPropertyVelocityReference(String identifier, String propertyName) {
+        {
+            cesiumlanguagewriter.OrientationCesiumWriter writer = openOrientationProperty();
+            try {
+                writer.writeVelocityReference(identifier, propertyName);
+            } finally {
+                DisposeHelper.dispose(writer);
+            }
+        }
+    }
+
+    /**
+    *  
+    Writes a value for the {@code orientation} property as a {@code velocityReference} value.  The {@code orientation} property specifies the orientation of the object in the world.  The orientation has no direct visual representation, but it is used to orient models, cones, pyramids, and other graphical items attached to the object.
+    
+    
+    
+
+    * @param identifier The identifier of the object which contains the referenced property.
+    * @param propertyNames The hierarchy of properties to be indexed on the referenced object.
+    */
+    public final void writeOrientationPropertyVelocityReference(String identifier, String[] propertyNames) {
+        {
+            cesiumlanguagewriter.OrientationCesiumWriter writer = openOrientationProperty();
+            try {
+                writer.writeVelocityReference(identifier, propertyNames);
+            } finally {
+                DisposeHelper.dispose(writer);
+            }
+        }
+    }
+
+    /**
     *  Gets the writer for the {@code viewFrom} property.  The returned instance must be opened by calling the {@link CesiumElementWriter#open} method before it can be used for writing.  The {@code viewFrom} property defines a suggested camera location when viewing this object.  The property is specified as a Cartesian position in the East (x), North (y), Up (z) reference frame relative to the object's position.
     
 

--- a/Schema/Orientation.json
+++ b/Schema/Orientation.json
@@ -27,6 +27,11 @@
             "$ref": "ReferenceValue.json",
             "description": "The orientation specified as a reference to another property.",
             "czmlValue": true
+        },
+        "velocityReference": {
+            "$ref": "ReferenceValue.json",
+            "description": "The orientation specified as the normalized velocity vector of a position property. The reference must be to a `position` property.",
+            "czmlValue": true
         }
     }
 }


### PR DESCRIPTION
* Add support for `orientation` defined as the client-side calculation of the velocity direction, via the existing `velocityReference` concept.  As before, this still implies finite differencing, with the same limitations as before.  Fixes AnalyticalGraphicsInc/czml-writer#140

See AnalyticalGraphicsInc/cesium#5807