### PR TITLE
Update link to forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Binary releases are available for download on the [releases page](https://github
 
 ### Get Started ###
 
-Check out the [wiki](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki), including the [quick start](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Quick-Start) and [contributor's guide](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Contributor's-Guide).  Also browse the [forum](https://groups.google.com/d/forum/cesium-dev).
+Check out the [wiki](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki), including the [quick start](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Quick-Start) and [contributor's guide](https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/Contributor's-Guide).  Also browse the [forum](https://community.cesium.com/).


### PR DESCRIPTION
Since the forum has now moved, see: https://cesium.com/blog/2020/05/04/new-community-forum/ 